### PR TITLE
Add `run/3` interface with error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,11 +152,11 @@ process #PID<0.223.0> calculating square root of 1
 process #PID<0.225.0> calculating square root of 3
 process #PID<0.224.0> calculating square root of 2
 process #PID<0.226.0> calculating square root of 4
-1.0
-1.4142135623730951
-1.7320508075688772
-2.0
-2.23606797749979
-2.449489742783178
+{:ok, 1.0}
+{:ok, 1.4142135623730951}
+{:ok, 1.7320508075688772}
+{:ok, 2.0}
+{:ok, 2.23606797749979}
+{:ok, 2.449489742783178}
 ...
 ```

--- a/lib/poolex.ex
+++ b/lib/poolex.ex
@@ -26,11 +26,11 @@ defmodule Poolex do
   @spec run(pool_id(), (worker :: pid() -> any()), list(run_option())) ::
           {:ok, any()} | {:error, run_error()}
   def run(pool_id, fun, options \\ []) do
-    try do
-      run!(pool_id, fun, options)
-    catch
-      :exit, {:timeout, _meta} -> {:error, :all_workers_are_busy}
-    end
+    # TODO: надо ли хендлить и заворачивать ошибки?
+
+    run!(pool_id, fun, options)
+  catch
+    :exit, {:timeout, _meta} -> {:error, :all_workers_are_busy}
   end
 
   @spec run!(pool_id(), (worker :: pid() -> any()), list(run_option())) :: any()

--- a/lib/poolex.ex
+++ b/lib/poolex.ex
@@ -142,15 +142,18 @@ defmodule Poolex do
           waiting_callers: {[], []}
         } = state
       ) do
-    state = %State{
-      state
-      | busy_workers_count: busy_workers_count - 1,
-        busy_workers_pids: List.delete(busy_workers_pids, worker_pid),
-        idle_workers_count: idle_workers_count + 1,
-        idle_workers_pids: [worker_pid | idle_workers_pids]
-    }
-
-    {:noreply, state}
+    if Enum.member?(busy_workers_pids, worker_pid) do
+      {:noreply,
+       %State{
+         state
+         | busy_workers_count: busy_workers_count - 1,
+           busy_workers_pids: List.delete(busy_workers_pids, worker_pid),
+           idle_workers_count: idle_workers_count + 1,
+           idle_workers_pids: [worker_pid | idle_workers_pids]
+       }}
+    else
+      {:noreply, state}
+    end
   end
 
   def handle_cast(

--- a/lib/poolex.ex
+++ b/lib/poolex.ex
@@ -30,7 +30,7 @@ defmodule Poolex do
   @spec run(pool_id(), (worker :: pid() -> any()), list(run_option())) ::
           {:ok, any()} | :all_workers_are_busy | {:runtime_error, any()}
   def run(pool_id, fun, options \\ []) do
-    run!(pool_id, fun, options)
+    {:ok, run!(pool_id, fun, options)}
   catch
     :exit, {:timeout, _meta} -> :all_workers_are_busy
     :exit, reason -> {:runtime_error, reason}

--- a/lib/poolex.ex
+++ b/lib/poolex.ex
@@ -26,15 +26,11 @@ defmodule Poolex do
   def run(pool_id, fun, options \\ []) do
     timeout = Keyword.get(options, :timeout, @default_wait_timeout)
 
-    case GenServer.call(pool_id, :get_idle_worker, timeout) do
-      {:ok, pid} ->
-        result = fun.(pid)
-        GenServer.cast(pool_id, {:release_busy_worker, pid})
-        result
+    {:ok, pid} = GenServer.call(pool_id, :get_idle_worker, timeout)
+    result = fun.(pid)
 
-      error ->
-        error
-    end
+    GenServer.cast(pool_id, {:release_busy_worker, pid})
+    result
   end
 
   @spec get_state(pool_id()) :: State.t()

--- a/lib/poolex.ex
+++ b/lib/poolex.ex
@@ -16,6 +16,11 @@ defmodule Poolex do
           | {:worker_args, list(any())}
           | {:workers_count, pos_integer()}
 
+  @spec start(pool_id(), list(poolex_option())) :: GenServer.on_start()
+  def start(pool_id, opts) do
+    GenServer.start(__MODULE__, {pool_id, opts}, name: pool_id)
+  end
+
   @spec start_link(pool_id(), list(poolex_option())) :: GenServer.on_start()
   def start_link(pool_id, opts) do
     GenServer.start_link(__MODULE__, {pool_id, opts}, name: pool_id)
@@ -26,11 +31,10 @@ defmodule Poolex do
   @spec run(pool_id(), (worker :: pid() -> any()), list(run_option())) ::
           {:ok, any()} | {:error, run_error()}
   def run(pool_id, fun, options \\ []) do
-    # TODO: надо ли хендлить и заворачивать ошибки?
-
     run!(pool_id, fun, options)
   catch
     :exit, {:timeout, _meta} -> {:error, :all_workers_are_busy}
+    :exit, reason -> {:error, reason}
   end
 
   @spec run!(pool_id(), (worker :: pid() -> any()), list(run_option())) :: any()

--- a/lib/poolex.ex
+++ b/lib/poolex.ex
@@ -22,8 +22,17 @@ defmodule Poolex do
   end
 
   @type run_option() :: {:timeout, timeout()}
-  @spec run(pool_id(), (worker :: pid() -> any()), list(run_option())) :: any()
+  @type run_error() :: :all_workers_are_busy
+  @spec run(pool_id(), (worker :: pid() -> any()), list(run_option())) ::
+          {:ok, any()} | {:error, run_error()}
   def run(pool_id, fun, options \\ []) do
+    run!(pool_id, fun, options)
+  catch
+    {:exit, {:timeout, _meta}} -> {:error, :all_workers_are_busy}
+  end
+
+  @spec run!(pool_id(), (worker :: pid() -> any()), list(run_option())) :: any()
+  def run!(pool_id, fun, options \\ []) do
     timeout = Keyword.get(options, :timeout, @default_wait_timeout)
 
     {:ok, pid} = GenServer.call(pool_id, :get_idle_worker, timeout)

--- a/lib/poolex.ex
+++ b/lib/poolex.ex
@@ -27,14 +27,13 @@ defmodule Poolex do
   end
 
   @type run_option() :: {:timeout, timeout()}
-  @type run_error() :: :all_workers_are_busy
   @spec run(pool_id(), (worker :: pid() -> any()), list(run_option())) ::
-          {:ok, any()} | {:error, run_error()}
+          {:ok, any()} | :all_workers_are_busy | {:runtime_error, any()}
   def run(pool_id, fun, options \\ []) do
     run!(pool_id, fun, options)
   catch
-    :exit, {:timeout, _meta} -> {:error, :all_workers_are_busy}
-    :exit, reason -> {:error, reason}
+    :exit, {:timeout, _meta} -> :all_workers_are_busy
+    :exit, reason -> {:runtime_error, reason}
   end
 
   @spec run!(pool_id(), (worker :: pid() -> any()), list(run_option())) :: any()

--- a/lib/poolex/state.ex
+++ b/lib/poolex/state.ex
@@ -8,7 +8,8 @@ defmodule Poolex.State do
             worker_start_fun: nil,
             worker_args: [],
             waiting_callers: :queue.new(),
-            monitor_id: nil
+            monitor_id: nil,
+            supervisor: nil
 
   @type t() :: %__MODULE__{
           busy_workers_count: non_neg_integer(),
@@ -19,6 +20,7 @@ defmodule Poolex.State do
           worker_start_fun: atom(),
           worker_args: list(any()),
           waiting_callers: :queue.queue(),
-          monitor_id: atom() | reference()
+          monitor_id: atom() | reference(),
+          supervisor: pid()
         }
 end

--- a/lib/poolex/supervisor.ex
+++ b/lib/poolex/supervisor.ex
@@ -1,0 +1,11 @@
+defmodule Poolex.Supervisor do
+  use DynamicSupervisor
+
+  def start_link do
+    DynamicSupervisor.start_link(__MODULE__, nil)
+  end
+
+  def init(_arg) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+end

--- a/lib/poolex/supervisor.ex
+++ b/lib/poolex/supervisor.ex
@@ -1,4 +1,5 @@
 defmodule Poolex.Supervisor do
+  @moduledoc false
   use DynamicSupervisor
 
   def start_link do

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -81,6 +81,9 @@ defmodule PoolexTest do
       Poolex.start_link(pool_name, worker_module: SomeWorker, workers_count: 2)
 
       result = Poolex.run(pool_name, fn pid -> GenServer.call(pid, :do_some_work) end)
+      assert result == {:ok, :some_result}
+
+      result = Poolex.run!(pool_name, fn pid -> GenServer.call(pid, :do_some_work) end)
       assert result == :some_result
     end
 
@@ -91,7 +94,7 @@ defmodule PoolexTest do
         1..20
         |> Enum.map(fn _ ->
           Task.async(fn ->
-            Poolex.run(pool_name, fn pid ->
+            Poolex.run!(pool_name, fn pid ->
               GenServer.call(pid, {:do_some_work_with_delay, 100})
             end)
           end)

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -1,19 +1,21 @@
 defmodule PoolexTest do
   use ExUnit.Case
 
-  @pool_name :test_pool
+  setup do
+    [pool_name: pool_name()]
+  end
 
   describe "state" do
-    test "valid after initialization" do
+    test "valid after initialization", %{pool_name: pool_name} do
       initial_fun = fn -> 0 end
 
-      Poolex.start_link(@pool_name,
+      Poolex.start_link(pool_name,
         worker_module: Agent,
         worker_args: [initial_fun],
         workers_count: 5
       )
 
-      state = Poolex.get_state(@pool_name)
+      state = Poolex.get_state(pool_name)
 
       assert state.__struct__ == Poolex.State
       assert state.busy_workers_count == 0
@@ -25,10 +27,10 @@ defmodule PoolexTest do
       assert state.waiting_callers == :queue.new()
     end
 
-    test "valid after holding some workers" do
+    test "valid after holding some workers", %{pool_name: pool_name} do
       initial_fun = fn -> 0 end
 
-      Poolex.start_link(@pool_name,
+      Poolex.start_link(pool_name,
         worker_module: Agent,
         worker_args: [initial_fun],
         workers_count: 5
@@ -37,7 +39,7 @@ defmodule PoolexTest do
       test_process = self()
 
       spawn(fn ->
-        Poolex.run(@pool_name, fn _pid ->
+        Poolex.run(pool_name, fn _pid ->
           Process.send(test_process, nil, [])
           :timer.sleep(:timer.seconds(5))
         end)
@@ -47,7 +49,7 @@ defmodule PoolexTest do
         _message -> nil
       end
 
-      state = Poolex.get_state(@pool_name)
+      state = Poolex.get_state(pool_name)
 
       assert state.__struct__ == Poolex.State
       assert state.busy_workers_count == 1
@@ -61,35 +63,35 @@ defmodule PoolexTest do
   end
 
   describe "run/2" do
-    test "updates agent's state" do
-      Poolex.start_link(@pool_name,
+    test "updates agent's state", %{pool_name: pool_name} do
+      Poolex.start_link(pool_name,
         worker_module: Agent,
         worker_args: [fn -> 0 end],
         workers_count: 1
       )
 
-      Poolex.run(@pool_name, fn pid -> Agent.update(pid, fn _state -> 1 end) end)
+      Poolex.run(pool_name, fn pid -> Agent.update(pid, fn _state -> 1 end) end)
 
-      [agent_pid] = Poolex.get_state(@pool_name).idle_workers_pids
+      [agent_pid] = Poolex.get_state(pool_name).idle_workers_pids
 
       assert 1 == Agent.get(agent_pid, fn state -> state end)
     end
 
-    test "get result from custom worker" do
-      Poolex.start_link(@pool_name, worker_module: SomeWorker, workers_count: 2)
+    test "get result from custom worker", %{pool_name: pool_name} do
+      Poolex.start_link(pool_name, worker_module: SomeWorker, workers_count: 2)
 
-      result = Poolex.run(@pool_name, fn pid -> GenServer.call(pid, :do_some_work) end)
+      result = Poolex.run(pool_name, fn pid -> GenServer.call(pid, :do_some_work) end)
       assert result == :some_result
     end
 
-    test "test waiting queue" do
-      Poolex.start_link(@pool_name, worker_module: SomeWorker, workers_count: 5)
+    test "test waiting queue", %{pool_name: pool_name} do
+      Poolex.start_link(pool_name, worker_module: SomeWorker, workers_count: 5)
 
       result =
         1..20
         |> Enum.map(fn _ ->
           Task.async(fn ->
-            Poolex.run(@pool_name, fn pid ->
+            Poolex.run(pool_name, fn pid ->
               GenServer.call(pid, {:do_some_work_with_delay, 100})
             end)
           end)
@@ -102,27 +104,27 @@ defmodule PoolexTest do
   end
 
   describe "restarting terminated processes" do
-    test "works on idle workers" do
-      Poolex.start_link(@pool_name,
+    test "works on idle workers", %{pool_name: pool_name} do
+      Poolex.start_link(pool_name,
         worker_module: Agent,
         worker_args: [fn -> 0 end],
         workers_count: 1
       )
 
-      [agent_pid] = Poolex.get_state(@pool_name).idle_workers_pids
+      [agent_pid] = Poolex.get_state(pool_name).idle_workers_pids
 
       Process.exit(agent_pid, :kill)
 
       # To be sure that DOWN message will be handed
       :timer.sleep(1)
 
-      [new_agent_pid] = Poolex.get_state(@pool_name).idle_workers_pids
+      [new_agent_pid] = Poolex.get_state(pool_name).idle_workers_pids
 
       assert agent_pid != new_agent_pid
     end
 
-    test "works on busy workers" do
-      Poolex.start_link(@pool_name,
+    test "works on busy workers", %{pool_name: pool_name} do
+      Poolex.start_link(pool_name,
         worker_module: Agent,
         worker_args: [fn -> 0 end],
         workers_count: 1
@@ -131,7 +133,7 @@ defmodule PoolexTest do
       test_process = self()
 
       spawn(fn ->
-        Poolex.run(@pool_name, fn _pid ->
+        Poolex.run(pool_name, fn _pid ->
           Process.send(test_process, nil, [])
           :timer.sleep(:timer.seconds(5))
         end)
@@ -141,25 +143,25 @@ defmodule PoolexTest do
         _message -> nil
       end
 
-      [agent_pid] = Poolex.get_state(@pool_name).busy_workers_pids
+      [agent_pid] = Poolex.get_state(pool_name).busy_workers_pids
 
       Process.exit(agent_pid, :kill)
 
       # To be sure that DOWN message will be handed
       :timer.sleep(1)
 
-      [new_agent_pid] = Poolex.get_state(@pool_name).idle_workers_pids
+      [new_agent_pid] = Poolex.get_state(pool_name).idle_workers_pids
 
       assert agent_pid != new_agent_pid
     end
 
-    test "works on callers" do
-      Poolex.start_link(@pool_name, worker_module: SomeWorker, workers_count: 1)
+    test "works on callers", %{pool_name: pool_name} do
+      Poolex.start_link(pool_name, worker_module: SomeWorker, workers_count: 1)
 
       1..10
       |> Enum.each(fn _ ->
         spawn(fn ->
-          Poolex.run(@pool_name, fn pid ->
+          Poolex.run(pool_name, fn pid ->
             GenServer.call(pid, {:do_some_work_with_delay, :timer.seconds(4)})
           end)
         end)
@@ -167,14 +169,14 @@ defmodule PoolexTest do
 
       waiting_caller =
         spawn(fn ->
-          Poolex.run(@pool_name, fn pid ->
+          Poolex.run(pool_name, fn pid ->
             GenServer.call(pid, {:do_some_work_with_delay, :timer.seconds(3)})
           end)
         end)
 
       :timer.sleep(10)
 
-      state = Poolex.get_state(@pool_name)
+      state = Poolex.get_state(pool_name)
       assert :queue.len(state.waiting_callers) == 10
 
       assert Enum.find(:queue.to_list(state.waiting_callers), fn {pid, _} ->
@@ -184,7 +186,7 @@ defmodule PoolexTest do
       Process.exit(waiting_caller, :kill)
       :timer.sleep(10)
 
-      state = Poolex.get_state(@pool_name)
+      state = Poolex.get_state(pool_name)
       assert :queue.len(state.waiting_callers) == 9
 
       refute Enum.find(:queue.to_list(state.waiting_callers), fn {pid, _} ->
@@ -192,13 +194,13 @@ defmodule PoolexTest do
              end)
     end
 
-    test "runtime errors" do
-      Poolex.start(@pool_name, worker_module: SomeWorker, workers_count: 1)
-      Poolex.run(@pool_name, fn pid -> GenServer.call(pid, :do_raise) end)
+    test "runtime errors", %{pool_name: pool_name} do
+      Poolex.start(pool_name, worker_module: SomeWorker, workers_count: 1)
+      Poolex.run(pool_name, fn pid -> GenServer.call(pid, :do_raise) end)
 
       :timer.sleep(10)
 
-      state = Poolex.get_state(@pool_name)
+      state = Poolex.get_state(pool_name)
 
       assert state.busy_workers_count == 0
       assert state.idle_workers_count == 1
@@ -207,11 +209,11 @@ defmodule PoolexTest do
   end
 
   describe "timeouts" do
-    test "when caller waits too long" do
-      Poolex.start_link(@pool_name, worker_module: SomeWorker, workers_count: 1)
+    test "when caller waits too long", %{pool_name: pool_name} do
+      Poolex.start_link(pool_name, worker_module: SomeWorker, workers_count: 1)
 
       spawn(fn ->
-        Poolex.run(@pool_name, fn pid ->
+        Poolex.run(pool_name, fn pid ->
           GenServer.call(pid, {:do_some_work_with_delay, :timer.seconds(4)})
         end)
       end)
@@ -221,7 +223,7 @@ defmodule PoolexTest do
       waiting_caller =
         spawn(fn ->
           Poolex.run(
-            @pool_name,
+            pool_name,
             fn pid ->
               GenServer.call(pid, {:do_some_work_with_delay, :timer.seconds(4)})
             end,
@@ -231,7 +233,7 @@ defmodule PoolexTest do
 
       :timer.sleep(10)
 
-      state = Poolex.get_state(@pool_name)
+      state = Poolex.get_state(pool_name)
       assert :queue.len(state.waiting_callers) == 1
 
       assert Enum.find(:queue.to_list(state.waiting_callers), fn {pid, _} ->
@@ -239,16 +241,16 @@ defmodule PoolexTest do
              end)
 
       :timer.sleep(100)
-      state = Poolex.get_state(@pool_name)
+      state = Poolex.get_state(pool_name)
       assert :queue.len(state.waiting_callers) == 0
     end
 
-    test "run/3 returns error tuple on timeout" do
-      Poolex.start_link(@pool_name, worker_module: SomeWorker, workers_count: 1)
+    test "run/3 returns error tuple on timeout", %{pool_name: pool_name} do
+      Poolex.start_link(pool_name, worker_module: SomeWorker, workers_count: 1)
 
       spawn(fn ->
         Poolex.run(
-          @pool_name,
+          pool_name,
           fn pid -> GenServer.call(pid, {:do_some_work_with_delay, :timer.seconds(4)}) end
         )
       end)
@@ -257,7 +259,7 @@ defmodule PoolexTest do
 
       result =
         Poolex.run(
-          @pool_name,
+          pool_name,
           fn pid -> GenServer.call(pid, {:do_some_work_with_delay, :timer.seconds(4)}) end,
           timeout: 100
         )
@@ -265,12 +267,12 @@ defmodule PoolexTest do
       assert result == {:error, :all_workers_are_busy}
     end
 
-    test "run!/3 exits on timeout" do
-      Poolex.start_link(@pool_name, worker_module: SomeWorker, workers_count: 1)
+    test "run!/3 exits on timeout", %{pool_name: pool_name} do
+      Poolex.start_link(pool_name, worker_module: SomeWorker, workers_count: 1)
 
       spawn(fn ->
         Poolex.run(
-          @pool_name,
+          pool_name,
           fn pid -> GenServer.call(pid, {:do_some_work_with_delay, :timer.seconds(4)}) end
         )
       end)
@@ -279,11 +281,18 @@ defmodule PoolexTest do
 
       assert catch_exit(
                Poolex.run!(
-                 @pool_name,
+                 pool_name,
                  fn pid -> GenServer.call(pid, {:do_some_work_with_delay, :timer.seconds(4)}) end,
                  timeout: 100
                )
-             ) == {:timeout, {GenServer, :call, [@pool_name, :get_idle_worker, 100]}}
+             ) == {:timeout, {GenServer, :call, [pool_name, :get_idle_worker, 100]}}
     end
+  end
+
+  defp pool_name do
+    1..10
+    |> Enum.map(fn _ -> Enum.random(?a..?z) end)
+    |> to_string()
+    |> String.to_atom()
   end
 end

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -245,7 +245,7 @@ defmodule PoolexTest do
       assert :queue.len(state.waiting_callers) == 0
     end
 
-    test "run/3 returns error tuple on timeout", %{pool_name: pool_name} do
+    test "run/3 returns :all_workers_are_busy on timeout", %{pool_name: pool_name} do
       Poolex.start_link(pool_name, worker_module: SomeWorker, workers_count: 1)
 
       spawn(fn ->
@@ -264,7 +264,7 @@ defmodule PoolexTest do
           timeout: 100
         )
 
-      assert result == {:error, :all_workers_are_busy}
+      assert result == :all_workers_are_busy
     end
 
     test "run!/3 exits on timeout", %{pool_name: pool_name} do

--- a/test/support/some_worker.ex
+++ b/test/support/some_worker.ex
@@ -19,4 +19,10 @@ defmodule SomeWorker do
 
     {:reply, :some_result, state}
   end
+
+  def handle_call(:do_raise, _from, state) do
+    raise RuntimeError
+
+    {:reply, nil, state}
+  end
 end


### PR DESCRIPTION
## New interface

New `run/3` interface will return `{:error, reason :: any()}` instead of raising errors or throwing exit code.
`run!/3` will raise errors as earlier.

## Enhancements

- Use [DynamicSupervisor](https://hexdocs.pm/elixir/1.14.3/DynamicSupervisor.html) to manage workers
- Fix bug on workers releasing (now we check if it can be released)

Closes #14 