### PR TITLE
Change `worker_start_fun` default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The default value of the parameter `:worker_start_fun` changed from `:start` to `:start_link`, since the second value is used more often.
+
 ## [0.4.0] - 2023-02-18
 
 ### Added

--- a/docs/guides/example-of-use.md
+++ b/docs/guides/example-of-use.md
@@ -11,8 +11,8 @@ We describe an actor that can easily become a bottleneck in our application, sin
 defmodule PoolexExample.Worker do
   use GenServer
 
-  def start do
-    GenServer.start(__MODULE__, nil)
+  def start_link do
+    GenServer.start_link(__MODULE__, nil)
   end
 
   def init(_args) do

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -34,7 +34,7 @@ The second argument should contain a set of options for starting the pool.
 | Option             | Description                                    | Example        | Default value          |
 |--------------------|------------------------------------------------|----------------|------------------------|
 | `worker_module`    | Name of module that implements our worker      | `MyApp.Worker` | **option is required** |
-| `worker_start_fun` | Name of the function that starts the worker    | `:run`         | `:start`               |
+| `worker_start_fun` | Name of the function that starts the worker    | `:run`         | `:start_link`          |
 | `worker_args`      | List of arguments passed to the start function | `[:gg, "wp"]`  | `[]`                   |
 | `workers_count`    | How many workers should be running in the pool | `5`            | **option is required** |
 | `max_overflow`     | How many workers can be created over the limit | `2`            | `0`                    |

--- a/examples/poolex_example/lib/poolex_example/worker.ex
+++ b/examples/poolex_example/lib/poolex_example/worker.ex
@@ -1,8 +1,8 @@
 defmodule PoolexExample.Worker do
   use GenServer
 
-  def start do
-    GenServer.start(__MODULE__, nil)
+  def start_link do
+    GenServer.start_link(__MODULE__, nil)
   end
 
   def init(_args) do

--- a/examples/poolex_example/mix.exs
+++ b/examples/poolex_example/mix.exs
@@ -21,7 +21,7 @@ defmodule PoolexExample.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:poolex, "~> 0.4.0"},
+      {:poolex, path: "../.."},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false}
     ]
   end

--- a/lib/poolex.ex
+++ b/lib/poolex.ex
@@ -78,7 +78,7 @@ defmodule Poolex do
   | Option             | Description                                    | Example        | Default value          |
   |--------------------|------------------------------------------------|----------------|------------------------|
   | `worker_module`    | Name of module that implements our worker      | `MyApp.Worker` | **option is required** |
-  | `worker_start_fun` | Name of the function that starts the worker    | `:run`         | `:start`               |
+  | `worker_start_fun` | Name of the function that starts the worker    | `:run`         | `:start_link`          |
   | `worker_args`      | List of arguments passed to the start function | `[:gg, "wp"]`  | `[]`                   |
   | `workers_count`    | How many workers should be running in the pool | `5`            | **option is required** |
   | `max_overflow`     | How many workers can be created over the limit | `2`            | `0`                    |
@@ -205,7 +205,7 @@ defmodule Poolex do
     worker_module = Keyword.fetch!(opts, :worker_module)
     workers_count = Keyword.fetch!(opts, :workers_count)
 
-    worker_start_fun = Keyword.get(opts, :worker_start_fun, :start)
+    worker_start_fun = Keyword.get(opts, :worker_start_fun, :start_link)
     worker_args = Keyword.get(opts, :worker_args, [])
     max_overflow = Keyword.get(opts, :max_overflow, 0)
 

--- a/lib/poolex/debug_info.ex
+++ b/lib/poolex/debug_info.ex
@@ -14,7 +14,7 @@ defmodule Poolex.DebugInfo do
             waiting_callers: [],
             worker_args: [],
             worker_module: nil,
-            worker_start_fun: :start
+            worker_start_fun: nil
 
   @type t() :: %__MODULE__{
           busy_workers_count: non_neg_integer(),

--- a/test/support/some_worker.ex
+++ b/test/support/some_worker.ex
@@ -2,8 +2,8 @@ defmodule SomeWorker do
   @moduledoc false
   use GenServer
 
-  def start do
-    GenServer.start(__MODULE__, [])
+  def start_link do
+    GenServer.start_link(__MODULE__, [])
   end
 
   def init(_options) do


### PR DESCRIPTION
The default value of the parameter `:worker_start_fun` changed from `:start` to `:start_link`, since the second value is used more often.