### PR TITLE
Rework `start`, `start_link` and `child_spec`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The default value of the parameter `:worker_start_fun` changed from `:start` to `:start_link`, since the second value is used more often.
+- [INCOMPATIBLE] Reworked pool launch functions `start` and `start_link`
+  - First argument `pool_id` moved to `poolex_options` under required key `:pool_id`. So the arity of both functions has changed to `1`.
+
+    ```elixir
+    # Before
+    Poolex.start(:my_pool, worker_module: Agent, workers_count: 5)
+
+    # After
+    Poolex.start(pool_id: :my_pool, worker_module: Agent, workers_count: 5)
+    ```
+
+  - `child_spec/1` was redefined to support `:pool_id` key in `poolex_options`. Now the pool can be added to the supervisor tree in a more convenient way.
+
+    ```elixir
+    children = [
+        Poolex.child_spec(pool_id: :worker_pool_1, worker_module: SomeWorker, workers_count: 5),
+        # or in another way
+        {Poolex, [pool_id: :worker_pool_2, worker_module: SomeOtherWorker, workers_count: 5]}
+      ]
+
+      Supervisor.start_link(children, strategy: :one_for_one)
+    ```
 
 ## [0.4.0] - 2023-02-18
 

--- a/README.md
+++ b/README.md
@@ -65,16 +65,12 @@ end
 In the most typical use of Poolex, you only need to start pool of workers as a child of your application.
 
 ```elixir
-pool_config = [
-  worker_module: SomeWorker,
-  workers_count: 5
-]
-
 children = [
-  %{
-    id: :worker_pool,
-    start: {Poolex, :start_link, [:worker_pool, pool_config]}
-  }
+  Poolex.child_spec(
+    pool_id: :worker_pool,
+    worker_module: SomeWorker,
+    workers_count: 5
+  )
 ]
 
 Supervisor.start_link(children, strategy: :one_for_one)

--- a/docs/guides/example-of-use.md
+++ b/docs/guides/example-of-use.md
@@ -35,20 +35,13 @@ defmodule PoolexExample.Application do
 
   use Application
 
-  defp pool_config do
-    [
-      worker_module: PoolexExample.Worker,
-      workers_count: 5,
-      max_overflow: 2
-    ]
-  end
-
   def start(_type, _args) do
-    children = [
-      %{
-        id: :worker_pool,
-        start: {Poolex, :start_link, [:worker_pool, pool_config()]}
-      }
+      Poolex.child_spec(
+        pool_id: :worker_pool,
+        worker_module: PoolexExample.Worker,
+        workers_count: 5,
+        max_overflow: 2
+      )
     ]
 
     Supervisor.start_link(children, strategy: :one_for_one)

--- a/examples/poolex_example/lib/poolex_example/application.ex
+++ b/examples/poolex_example/lib/poolex_example/application.ex
@@ -3,20 +3,15 @@ defmodule PoolexExample.Application do
 
   use Application
 
-  defp worker_config do
-    [
-      worker_module: PoolexExample.Worker,
-      workers_count: 5,
-      max_overflow: 2
-    ]
-  end
-
   def start(_type, _args) do
     children = [
-      %{
-        id: :worker_pool,
-        start: {Poolex, :start_link, [:worker_pool, worker_config()]}
-      }
+      {Poolex,
+       [
+         pool_id: :worker_pool,
+         worker_module: PoolexExample.Worker,
+         workers_count: 5,
+         max_overflow: 2
+       ]}
     ]
 
     Supervisor.start_link(children, strategy: :one_for_one)

--- a/lib/poolex.ex
+++ b/lib/poolex.ex
@@ -99,6 +99,38 @@ defmodule Poolex do
   end
 
   @doc """
+  You need to use child_spec/2 to set the required pool_id parameter.
+  """
+  @spec child_spec(any()) :: no_return()
+  def child_spec(_args) do
+    raise "Use child_spec/2 to set required pool_id"
+  end
+
+  @doc """
+  Returns a specification to start this module under a supervisor.
+
+  This function can be used if you want to run multiple pools from the supervisor tree.
+  Just like the fun_name function takes a pool ID as the first parameter and options as the second.
+
+  ## Options
+
+  #{@poolex_options_table}
+
+  ## Examples
+
+      children = [
+        Poolex.child_spec(:worker_pool_1, worker_module: SomeWorker, workers_count: 5),
+        Poolex.child_spec(:worker_pool_2, worker_module: SomeOtherWorker, workers_count: 5)
+      ]
+
+      Supervisor.start_link(children, strategy: :one_for_one)
+  """
+  @spec child_spec(pool_id(), list(poolex_option())) :: Supervisor.child_spec()
+  def child_spec(pool_id, opts) do
+    %{id: pool_id, start: {Poolex, :start_link, [pool_id, opts]}}
+  end
+
+  @doc """
   Same as `run!/3` but handles runtime_errors.
 
   Returns:

--- a/lib/poolex.ex
+++ b/lib/poolex.ex
@@ -5,16 +5,12 @@ defmodule Poolex do
   In the most typical use of Poolex, you only need to start pool of workers as a child of your application.
 
   ```elixir
-  pool_config = [
-    worker_module: SomeWorker,
-    workers_count: 5
-  ]
-
   children = [
-    %{
-      id: :worker_pool,
-      start: {Poolex, :start_link, [:worker_pool, pool_config]}
-    }
+    Poolex.child_spec(
+      pool_id: :worker_pool,
+      worker_module: SomeWorker,
+      workers_count: 5
+    )
   ]
 
   Supervisor.start_link(children, strategy: :one_for_one)
@@ -113,7 +109,8 @@ defmodule Poolex do
 
       children = [
         Poolex.child_spec(pool_id: :worker_pool_1, worker_module: SomeWorker, workers_count: 5),
-        Poolex.child_spec(pool_id: :worker_pool_2, worker_module: SomeOtherWorker, workers_count: 5)
+        # or another way
+        {Poolex, [pool_id: :worker_pool_2, worker_module: SomeOtherWorker, workers_count: 5]}
       ]
 
       Supervisor.start_link(children, strategy: :one_for_one)

--- a/lib/poolex.ex
+++ b/lib/poolex.ex
@@ -40,6 +40,15 @@ defmodule Poolex do
   alias Poolex.WaitingCallers
 
   @default_wait_timeout :timer.seconds(5)
+  @poolex_options_table """
+  | Option             | Description                                    | Example        | Default value          |
+  |--------------------|------------------------------------------------|----------------|------------------------|
+  | `worker_module`    | Name of module that implements our worker      | `MyApp.Worker` | **option is required** |
+  | `worker_start_fun` | Name of the function that starts the worker    | `:run`         | `:start_link`          |
+  | `worker_args`      | List of arguments passed to the start function | `[:gg, "wp"]`  | `[]`                   |
+  | `workers_count`    | How many workers should be running in the pool | `5`            | **option is required** |
+  | `max_overflow`     | How many workers can be created over the limit | `2`            | `0`                    |
+  """
 
   @type pool_id() :: atom()
   @type poolex_option() ::
@@ -75,13 +84,7 @@ defmodule Poolex do
 
   ## Options
 
-  | Option             | Description                                    | Example        | Default value          |
-  |--------------------|------------------------------------------------|----------------|------------------------|
-  | `worker_module`    | Name of module that implements our worker      | `MyApp.Worker` | **option is required** |
-  | `worker_start_fun` | Name of the function that starts the worker    | `:run`         | `:start_link`          |
-  | `worker_args`      | List of arguments passed to the start function | `[:gg, "wp"]`  | `[]`                   |
-  | `workers_count`    | How many workers should be running in the pool | `5`            | **option is required** |
-  | `max_overflow`     | How many workers can be created over the limit | `2`            | `0`                    |
+  #{@poolex_options_table}
 
   ## Examples
 

--- a/lib/poolex.ex
+++ b/lib/poolex.ex
@@ -109,7 +109,7 @@ defmodule Poolex do
 
       children = [
         Poolex.child_spec(pool_id: :worker_pool_1, worker_module: SomeWorker, workers_count: 5),
-        # or another way
+        # or in another way
         {Poolex, [pool_id: :worker_pool_2, worker_module: SomeOtherWorker, workers_count: 5]}
       ]
 

--- a/lib/poolex.ex
+++ b/lib/poolex.ex
@@ -103,18 +103,7 @@ defmodule Poolex do
   end
 
   @doc """
-  You need to use child_spec/2 to set the required pool_id parameter.
-  """
-  @spec child_spec(any()) :: no_return()
-  def child_spec(_args) do
-    raise "Use child_spec/2 to set required pool_id"
-  end
-
-  @doc """
   Returns a specification to start this module under a supervisor.
-
-  This function can be used if you want to run multiple pools from the supervisor tree.
-  Just like the fun_name function takes a pool ID as the first parameter and options as the second.
 
   ## Options
 
@@ -123,15 +112,16 @@ defmodule Poolex do
   ## Examples
 
       children = [
-        Poolex.child_spec(:worker_pool_1, worker_module: SomeWorker, workers_count: 5),
-        Poolex.child_spec(:worker_pool_2, worker_module: SomeOtherWorker, workers_count: 5)
+        Poolex.child_spec(pool_id: :worker_pool_1, worker_module: SomeWorker, workers_count: 5),
+        Poolex.child_spec(pool_id: :worker_pool_2, worker_module: SomeOtherWorker, workers_count: 5)
       ]
 
       Supervisor.start_link(children, strategy: :one_for_one)
   """
-  @spec child_spec(pool_id(), list(poolex_option())) :: Supervisor.child_spec()
-  def child_spec(pool_id, opts) do
-    %{id: pool_id, start: {Poolex, :start_link, [pool_id, opts]}}
+  @spec child_spec(list(poolex_option())) :: Supervisor.child_spec()
+  def child_spec(opts) do
+    pool_id = Keyword.fetch!(opts, :pool_id)
+    %{id: pool_id, start: {Poolex, :start_link, [opts]}}
   end
 
   @doc """

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -325,6 +325,24 @@ defmodule PoolexTest do
     end
   end
 
+  describe "child_spec" do
+    test "child_spec/1" do
+      assert Poolex.child_spec(worker_module: SomeWorker, workers_count: 5) == %{
+               id: Poolex,
+               start:
+                 {Poolex, :start_link, [Poolex, [worker_module: SomeWorker, workers_count: 5]]}
+             }
+    end
+
+    test "child_spec/2", %{pool_name: pool_name} do
+      assert Poolex.child_spec(pool_name, worker_module: SomeWorker, workers_count: 5) == %{
+               id: pool_name,
+               start:
+                 {Poolex, :start_link, [pool_name, [worker_module: SomeWorker, workers_count: 5]]}
+             }
+    end
+  end
+
   defp pool_name do
     1..10
     |> Enum.map(fn _ -> Enum.random(?a..?z) end)

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -10,7 +10,8 @@ defmodule PoolexTest do
     test "valid after initialization", %{pool_name: pool_name} do
       initial_fun = fn -> 0 end
 
-      Poolex.start_link(pool_name,
+      Poolex.start_link(
+        pool_id: pool_name,
         worker_module: Agent,
         worker_args: [initial_fun],
         workers_count: 5
@@ -32,7 +33,8 @@ defmodule PoolexTest do
     test "valid after holding some workers", %{pool_name: pool_name} do
       initial_fun = fn -> 0 end
 
-      Poolex.start_link(pool_name,
+      Poolex.start_link(
+        pool_id: pool_name,
         worker_module: Agent,
         worker_args: [initial_fun],
         workers_count: 5
@@ -66,7 +68,8 @@ defmodule PoolexTest do
 
   describe "run/2" do
     test "updates agent's state", %{pool_name: pool_name} do
-      Poolex.start_link(pool_name,
+      Poolex.start_link(
+        pool_id: pool_name,
         worker_module: Agent,
         worker_args: [fn -> 0 end],
         workers_count: 1
@@ -80,7 +83,7 @@ defmodule PoolexTest do
     end
 
     test "get result from custom worker", %{pool_name: pool_name} do
-      Poolex.start_link(pool_name, worker_module: SomeWorker, workers_count: 2)
+      Poolex.start_link(pool_id: pool_name, worker_module: SomeWorker, workers_count: 2)
 
       result = Poolex.run(pool_name, fn pid -> GenServer.call(pid, :do_some_work) end)
       assert result == {:ok, :some_result}
@@ -90,7 +93,7 @@ defmodule PoolexTest do
     end
 
     test "test waiting queue", %{pool_name: pool_name} do
-      Poolex.start_link(pool_name, worker_module: SomeWorker, workers_count: 5)
+      Poolex.start_link(pool_id: pool_name, worker_module: SomeWorker, workers_count: 5)
 
       result =
         1..20
@@ -110,7 +113,8 @@ defmodule PoolexTest do
 
   describe "restarting terminated processes" do
     test "works on idle workers", %{pool_name: pool_name} do
-      Poolex.start_link(pool_name,
+      Poolex.start_link(
+        pool_id: pool_name,
         worker_module: Agent,
         worker_args: [fn -> 0 end],
         workers_count: 1
@@ -129,7 +133,8 @@ defmodule PoolexTest do
     end
 
     test "works on busy workers", %{pool_name: pool_name} do
-      Poolex.start_link(pool_name,
+      Poolex.start_link(
+        pool_id: pool_name,
         worker_module: Agent,
         worker_args: [fn -> 0 end],
         workers_count: 1
@@ -161,7 +166,7 @@ defmodule PoolexTest do
     end
 
     test "works on callers", %{pool_name: pool_name} do
-      Poolex.start_link(pool_name, worker_module: SomeWorker, workers_count: 1)
+      Poolex.start_link(pool_id: pool_name, worker_module: SomeWorker, workers_count: 1)
 
       1..10
       |> Enum.each(fn _ ->
@@ -200,7 +205,7 @@ defmodule PoolexTest do
     end
 
     test "runtime errors", %{pool_name: pool_name} do
-      Poolex.start(pool_name, worker_module: SomeWorker, workers_count: 1)
+      Poolex.start(pool_id: pool_name, worker_module: SomeWorker, workers_count: 1)
       Poolex.run(pool_name, fn pid -> GenServer.call(pid, :do_raise) end)
 
       :timer.sleep(10)
@@ -215,7 +220,7 @@ defmodule PoolexTest do
 
   describe "timeouts" do
     test "when caller waits too long", %{pool_name: pool_name} do
-      Poolex.start_link(pool_name, worker_module: SomeWorker, workers_count: 1)
+      Poolex.start_link(pool_id: pool_name, worker_module: SomeWorker, workers_count: 1)
 
       launch_long_task(pool_name)
 
@@ -245,7 +250,7 @@ defmodule PoolexTest do
     end
 
     test "run/3 returns :all_workers_are_busy on timeout", %{pool_name: pool_name} do
-      Poolex.start_link(pool_name, worker_module: SomeWorker, workers_count: 1)
+      Poolex.start_link(pool_id: pool_name, worker_module: SomeWorker, workers_count: 1)
 
       launch_long_task(pool_name)
 
@@ -260,7 +265,7 @@ defmodule PoolexTest do
     end
 
     test "run!/3 exits on timeout", %{pool_name: pool_name} do
-      Poolex.start_link(pool_name, worker_module: SomeWorker, workers_count: 1)
+      Poolex.start_link(pool_id: pool_name, worker_module: SomeWorker, workers_count: 1)
 
       launch_long_task(pool_name)
 
@@ -276,7 +281,12 @@ defmodule PoolexTest do
 
   describe "overflow" do
     test "create new workers when possible", %{pool_name: pool_name} do
-      Poolex.start_link(pool_name, worker_module: SomeWorker, workers_count: 1, max_overflow: 5)
+      Poolex.start_link(
+        pool_id: pool_name,
+        worker_module: SomeWorker,
+        workers_count: 1,
+        max_overflow: 5
+      )
 
       launch_long_tasks(pool_name, 5)
 
@@ -287,7 +297,7 @@ defmodule PoolexTest do
     end
 
     test "return error when max count of workers reached", %{pool_name: pool_name} do
-      Poolex.start_link(pool_name, worker_module: SomeWorker, workers_count: 1)
+      Poolex.start_link(pool_id: pool_name, worker_module: SomeWorker, workers_count: 1)
 
       launch_long_task(pool_name)
 
@@ -308,7 +318,12 @@ defmodule PoolexTest do
     end
 
     test "all workers running over the limit are turned off after use", %{pool_name: pool_name} do
-      Poolex.start_link(pool_name, worker_module: SomeWorker, workers_count: 1, max_overflow: 2)
+      Poolex.start_link(
+        pool_id: pool_name,
+        worker_module: SomeWorker,
+        workers_count: 1,
+        max_overflow: 2
+      )
 
       launch_long_task(pool_name)
 

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -341,20 +341,14 @@ defmodule PoolexTest do
   end
 
   describe "child_spec" do
-    test "child_spec/1" do
-      assert Poolex.child_spec(worker_module: SomeWorker, workers_count: 5) == %{
-               id: Poolex,
-               start:
-                 {Poolex, :start_link, [Poolex, [worker_module: SomeWorker, workers_count: 5]]}
-             }
-    end
-
-    test "child_spec/2", %{pool_name: pool_name} do
-      assert Poolex.child_spec(pool_name, worker_module: SomeWorker, workers_count: 5) == %{
-               id: pool_name,
-               start:
-                 {Poolex, :start_link, [pool_name, [worker_module: SomeWorker, workers_count: 5]]}
-             }
+    test "child_spec/1", %{pool_name: pool_name} do
+      assert Poolex.child_spec(pool_id: pool_name, worker_module: SomeWorker, workers_count: 5) ==
+               %{
+                 id: pool_name,
+                 start:
+                   {Poolex, :start_link,
+                    [[pool_id: pool_name, worker_module: SomeWorker, workers_count: 5]]}
+               }
     end
   end
 


### PR DESCRIPTION
### Changed

- [INCOMPATIBLE] Reworked pool launch functions `start` and `start_link`
  - First argument `pool_id` moved to `poolex_options` under required key `:pool_id`. So the arity of both functions has changed to `1`.

    ```elixir
    # Before
    Poolex.start(:my_pool, worker_module: Agent, workers_count: 5)
    # After
    Poolex.start(pool_id: :my_pool, worker_module: Agent, workers_count: 5)
    ```

  - `child_spec/1` was redefined to support `:pool_id` key in `poolex_options`. Now the pool can be added to the supervisor tree in a more convenient way.

    ```elixir
    children = [
        Poolex.child_spec(pool_id: :worker_pool_1, worker_module: SomeWorker, workers_count: 5),
        # or in another way
        {Poolex, [pool_id: :worker_pool_2, worker_module: SomeOtherWorker, workers_count: 5]}
      ]
      Supervisor.start_link(children, strategy: :one_for_one)
    ```

Closes #27 