### PR TITLE
Handle shutdown process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix the shutdown process: stop workers before the pool ([issue](https://github.com/general-CbIC/poolex/issues/44)).
+
 ## [0.7.0] - 2023-04-13
 
 ### Added

--- a/lib/poolex.ex
+++ b/lib/poolex.ex
@@ -476,6 +476,7 @@ defmodule Poolex do
   @impl GenServer
   def terminate(reason, %State{} = state) do
     DynamicSupervisor.stop(state.supervisor, reason)
+    Monitoring.stop(state.monitor_id)
 
     :ok
   end

--- a/lib/poolex.ex
+++ b/lib/poolex.ex
@@ -472,4 +472,11 @@ defmodule Poolex do
         {:noreply, %{state | waiting_callers_state: new_waiting_callers_state}}
     end
   end
+
+  @impl GenServer
+  def terminate(reason, %State{} = state) do
+    DynamicSupervisor.stop(state.supervisor, reason)
+
+    :ok
+  end
 end

--- a/lib/poolex/monitoring.ex
+++ b/lib/poolex/monitoring.ex
@@ -11,6 +11,14 @@ defmodule Poolex.Monitoring do
     {:ok, monitor_id}
   end
 
+  @spec stop(monitor_id()) :: :ok
+  @doc false
+  def stop(monitor_id) do
+    :ets.delete(monitor_id)
+
+    :ok
+  end
+
   @spec add(monitor_id(), pid(), kind_of_process()) :: :ok
   @doc false
   def add(monitor_id, process_pid, kind_of_process) do

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -377,7 +377,9 @@ defmodule PoolexTest do
       {:ok, pool_pid} =
         Poolex.start_link(pool_id: pool_name, worker_module: SomeWorker, workers_count: 1)
 
-      supervisor_pid = Poolex.get_state(pool_name).supervisor
+      state = Poolex.get_state(pool_name)
+
+      supervisor_pid = state.supervisor
       worker_pid = Poolex.run!(pool_name, fn pid -> pid end)
 
       pool_monitor_ref = Process.monitor(pool_pid)


### PR DESCRIPTION
Add `terminate/2` callback to Poolex's GenServer to handle the shutdown process.

This relates to issue #44.