### PR TITLE
Allow workers_count: 0

### DIFF
--- a/lib/poolex.ex
+++ b/lib/poolex.ex
@@ -298,7 +298,7 @@ defmodule Poolex do
     {:ok, %State{state | idle_workers_state: IdleWorkers.init(idle_workers_impl, worker_pids)}}
   end
 
-  @spec start_workers(non_neg_integer(), State.t(), Monitoring.id()) :: [pid]
+  @spec start_workers(non_neg_integer(), State.t(), Monitoring.monitor_id()) :: [pid]
   defp start_workers(0, _state, _monitor_id) do
     []
   end

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -345,7 +345,7 @@ defmodule PoolexTest do
       assert debug_info.busy_workers_pids == [worker_pid]
       assert debug_info.overflow == 1
 
-      assert_receive {:traceable_end, :foo, ^worker_pid}, 5000
+      assert_receive {:traceable_end, :foo, ^worker_pid}
       debug_info = Poolex.get_debug_info(pool_name)
 
       assert debug_info.idle_workers_count == 0

--- a/test/support/some_worker.ex
+++ b/test/support/some_worker.ex
@@ -23,7 +23,6 @@ defmodule SomeWorker do
     {:reply, :ok, state}
   end
 
-  @impl true
   def handle_call(:do_some_work, _from, state) do
     {:reply, :some_result, state}
   end

--- a/test/support/some_worker.ex
+++ b/test/support/some_worker.ex
@@ -2,14 +2,28 @@ defmodule SomeWorker do
   @moduledoc false
   use GenServer
 
+  def traceable_call(server, pid, msg, delay) do
+    GenServer.call(server, {:traceable, pid, msg, delay})
+  end
+
   def start_link do
     GenServer.start_link(__MODULE__, [])
   end
 
+  @impl true
   def init(_options) do
     {:ok, :ok}
   end
 
+  @impl true
+  def handle_call({:traceable, pid, msg, delay}, _pid, state) do
+    send(pid, {:traceable_start, msg, self()})
+    :timer.sleep(delay)
+    Process.send_after(pid, {:traceable_end, msg, self()}, 10)
+    {:reply, :ok, state}
+  end
+
+  @impl true
   def handle_call(:do_some_work, _from, state) do
     {:reply, :some_result, state}
   end


### PR DESCRIPTION
Previously if you sent `workers_count: 0` it generated two workers. With negative numbers, it had similar behaviors. This PR fixes it without additional code.

I modified a little bit the way of testing using messages instead of "sleeping". It is considered a better practice in general.