### PR TITLE
Check pending callers after worker restart

### DIFF
--- a/lib/poolex.ex
+++ b/lib/poolex.ex
@@ -408,11 +408,7 @@ defmodule Poolex do
 
         state
       else
-        %State{
-          state
-          | idle_workers_state:
-              IdleWorkers.add(state.idle_workers_impl, state.idle_workers_state, worker)
-        }
+        add_worker_to_idle_workers(state, worker)
       end
     else
       state
@@ -453,14 +449,7 @@ defmodule Poolex do
               state
               |> remove_worker_from_idle_workers(dead_process_pid)
               |> remove_worker_from_busy_workers(dead_process_pid)
-
-            new_idle_workers_state =
-              IdleWorkers.add(state.idle_workers_impl, state.idle_workers_state, new_worker)
-
-            state = %State{
-              state
-              | idle_workers_state: new_idle_workers_state
-            }
+              |> add_worker_to_idle_workers(new_worker)
 
             {:noreply, state}
           end
@@ -490,6 +479,19 @@ defmodule Poolex do
       | busy_workers_state:
           BusyWorkers.add(
             state.busy_workers_impl,
+            state.busy_workers_state,
+            worker
+          )
+    }
+  end
+
+  @spec add_worker_to_idle_workers(State.t(), worker()) :: State.t()
+  defp add_worker_to_idle_workers(%State{} = state, worker) do
+    %State{
+      state
+      | idle_workers_state:
+          IdleWorkers.add(
+            state.idle_workers_impl,
             state.busy_workers_state,
             worker
           )

--- a/lib/poolex.ex
+++ b/lib/poolex.ex
@@ -450,12 +450,7 @@ defmodule Poolex do
       :worker ->
         if WaitingCallers.empty?(state.waiting_callers_impl, state.waiting_callers_state) do
           if state.overflow > 0 do
-            idle_workers_state =
-              IdleWorkers.remove(
-                state.idle_workers_impl,
-                state.idle_workers_state,
-                dead_process_pid
-              )
+            state = remove_worker_from_idle_workers(state, dead_process_pid)
 
             busy_workers_state =
               BusyWorkers.remove(
@@ -467,7 +462,6 @@ defmodule Poolex do
             state = %State{
               state
               | overflow: state.overflow - 1,
-                idle_workers_state: idle_workers_state,
                 busy_workers_state: busy_workers_state
             }
 
@@ -477,15 +471,10 @@ defmodule Poolex do
 
             Monitoring.add(state.monitor_id, new_worker, :worker)
 
-            temp_idle_workers_state =
-              IdleWorkers.remove(
-                state.idle_workers_impl,
-                state.idle_workers_state,
-                dead_process_pid
-              )
+            state = remove_worker_from_idle_workers(state, dead_process_pid)
 
             new_idle_workers_state =
-              IdleWorkers.add(state.idle_workers_impl, temp_idle_workers_state, new_worker)
+              IdleWorkers.add(state.idle_workers_impl, state.idle_workers_state, new_worker)
 
             state = %State{
               state
@@ -504,14 +493,10 @@ defmodule Poolex do
           {:ok, new_worker} = start_worker(state)
           Monitoring.add(state.monitor_id, new_worker, :worker)
 
-          state = provide_worker_to_waiting_caller(state, new_worker)
-
-          idle_workers_state =
-            IdleWorkers.remove(
-              state.idle_workers_impl,
-              state.idle_workers_state,
-              dead_process_pid
-            )
+          state =
+            state
+            |> provide_worker_to_waiting_caller(new_worker)
+            |> remove_worker_from_idle_workers(dead_process_pid)
 
           busy_workers_state =
             BusyWorkers.remove(
@@ -522,8 +507,7 @@ defmodule Poolex do
 
           state = %State{
             state
-            | idle_workers_state: idle_workers_state,
-              busy_workers_state:
+            | busy_workers_state:
                 BusyWorkers.add(state.busy_workers_impl, busy_workers_state, new_worker)
           }
 
@@ -533,6 +517,19 @@ defmodule Poolex do
       :caller ->
         {:noreply, handle_down_caller(state, dead_process_pid)}
     end
+  end
+
+  @spec remove_worker_from_idle_workers(State.t(), worker()) :: State.t()
+  defp remove_worker_from_idle_workers(%State{} = state, worker) do
+    %State{
+      state
+      | idle_workers_state:
+          IdleWorkers.remove(
+            state.idle_workers_impl,
+            state.idle_workers_state,
+            worker
+          )
+    }
   end
 
   @spec handle_down_caller(State.t(), pid()) :: State.t()

--- a/lib/poolex.ex
+++ b/lib/poolex.ex
@@ -336,7 +336,7 @@ defmodule Poolex do
       if state.overflow < state.max_overflow do
         {:ok, new_worker} = start_worker(state)
 
-        Monitoring.add(state.monitor_id, new_worker, :temporary_worker)
+        Monitoring.add(state.monitor_id, new_worker, :worker)
 
         new_state = %State{
           state
@@ -446,42 +446,88 @@ defmodule Poolex do
         %State{} = state
       ) do
     case Monitoring.remove(state.monitor_id, monitoring_reference) do
-      :temporary_worker ->
-        {:noreply,
-         %State{
-           state
-           | overflow: state.overflow - 1,
-             idle_workers_state:
-               IdleWorkers.remove(
-                 state.idle_workers_impl,
-                 state.idle_workers_state,
-                 dead_process_pid
-               )
-         }}
-
       :worker ->
-        {:ok, new_worker} = start_worker(state)
+        if WaitingCallers.empty?(state.waiting_callers_impl, state.waiting_callers_state) do
+          if state.overflow > 0 do
+            idle_workers_state =
+              IdleWorkers.remove(
+                state.idle_workers_impl,
+                state.idle_workers_state,
+                dead_process_pid
+              )
 
-        Monitoring.add(state.monitor_id, new_worker, :worker)
-
-        temp_idle_workers_state =
-          IdleWorkers.remove(state.idle_workers_impl, state.idle_workers_state, dead_process_pid)
-
-        new_idle_workers_state =
-          IdleWorkers.add(state.idle_workers_impl, temp_idle_workers_state, new_worker)
-
-        state = %State{
-          state
-          | idle_workers_state: new_idle_workers_state,
-            busy_workers_state:
+            busy_workers_state =
               BusyWorkers.remove(
                 state.busy_workers_impl,
                 state.busy_workers_state,
                 dead_process_pid
               )
-        }
 
-        {:noreply, state}
+            state = %State{
+              state
+              | overflow: state.overflow - 1,
+                idle_workers_state: idle_workers_state,
+                busy_workers_state: busy_workers_state
+            }
+
+            {:noreply, state}
+          else
+            {:ok, new_worker} = start_worker(state)
+
+            Monitoring.add(state.monitor_id, new_worker, :worker)
+
+            temp_idle_workers_state =
+              IdleWorkers.remove(
+                state.idle_workers_impl,
+                state.idle_workers_state,
+                dead_process_pid
+              )
+
+            new_idle_workers_state =
+              IdleWorkers.add(state.idle_workers_impl, temp_idle_workers_state, new_worker)
+
+            state = %State{
+              state
+              | idle_workers_state: new_idle_workers_state,
+                busy_workers_state:
+                  BusyWorkers.remove(
+                    state.busy_workers_impl,
+                    state.busy_workers_state,
+                    dead_process_pid
+                  )
+            }
+
+            {:noreply, state}
+          end
+        else
+          {:ok, new_worker} = start_worker(state)
+          Monitoring.add(state.monitor_id, new_worker, :worker)
+
+          state = provide_worker_to_waiting_caller(state, new_worker)
+
+          idle_workers_state =
+            IdleWorkers.remove(
+              state.idle_workers_impl,
+              state.idle_workers_state,
+              dead_process_pid
+            )
+
+          busy_workers_state =
+            BusyWorkers.remove(
+              state.busy_workers_impl,
+              state.busy_workers_state,
+              dead_process_pid
+            )
+
+          state = %State{
+            state
+            | idle_workers_state: idle_workers_state,
+              busy_workers_state:
+                BusyWorkers.add(state.busy_workers_impl, busy_workers_state, new_worker)
+          }
+
+          {:noreply, state}
+        end
 
       :caller ->
         new_waiting_callers_state =

--- a/lib/poolex.ex
+++ b/lib/poolex.ex
@@ -531,15 +531,20 @@ defmodule Poolex do
         end
 
       :caller ->
-        new_waiting_callers_state =
-          WaitingCallers.remove_by_pid(
-            state.waiting_callers_impl,
-            state.waiting_callers_state,
-            dead_process_pid
-          )
-
-        {:noreply, %{state | waiting_callers_state: new_waiting_callers_state}}
+        {:noreply, handle_down_caller(state, dead_process_pid)}
     end
+  end
+
+  @spec handle_down_caller(State.t(), pid()) :: State.t()
+  defp handle_down_caller(%State{} = state, dead_process_pid) do
+    new_waiting_callers_state =
+      WaitingCallers.remove_by_pid(
+        state.waiting_callers_impl,
+        state.waiting_callers_state,
+        dead_process_pid
+      )
+
+    %State{state | waiting_callers_state: new_waiting_callers_state}
   end
 
   @impl GenServer

--- a/lib/poolex.ex
+++ b/lib/poolex.ex
@@ -321,7 +321,8 @@ defmodule Poolex do
   defp start_worker(%State{} = state) do
     DynamicSupervisor.start_child(state.supervisor, %{
       id: make_ref(),
-      start: {state.worker_module, state.worker_start_fun, state.worker_args}
+      start: {state.worker_module, state.worker_start_fun, state.worker_args},
+      restart: :temporary
     })
   end
 

--- a/lib/poolex/monitoring.ex
+++ b/lib/poolex/monitoring.ex
@@ -1,7 +1,7 @@
 defmodule Poolex.Monitoring do
   @moduledoc false
   @type monitor_id() :: atom() | reference()
-  @type kind_of_process() :: :worker | :caller | :temporary_worker
+  @type kind_of_process() :: :worker | :caller
 
   @spec init(Poolex.pool_id()) :: {:ok, monitor_id()}
   @doc false

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -155,6 +155,31 @@ defmodule PoolexTest do
       assert agent_pid != new_agent_pid
     end
 
+    test "restart busy workers when pending callers" do
+      pool_name = start_pool(worker_module: SomeWorker, workers_count: 1)
+
+      # test_process = self()
+      launch_long_tasks(pool_name, 2)
+
+      debug_info = Poolex.get_debug_info(pool_name)
+      assert debug_info.busy_workers_count == 1
+      assert length(debug_info.waiting_callers) == 1
+
+      [busy_worker_pid] = debug_info.busy_workers_pids
+      Process.exit(busy_worker_pid, :kill)
+
+      # To be sure that DOWN message will be handed
+      :timer.sleep(1)
+
+      debug_info = Poolex.get_debug_info(pool_name)
+      assert debug_info.busy_workers_count == 1
+      assert length(debug_info.waiting_callers) == 0
+
+      [new_worker_pid] = debug_info.busy_workers_pids
+
+      assert busy_worker_pid != new_worker_pid
+    end
+
     test "works on callers" do
       pool_name = start_pool(worker_module: SomeWorker, workers_count: 1)
 

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -173,7 +173,7 @@ defmodule PoolexTest do
 
       debug_info = Poolex.get_debug_info(pool_name)
       assert debug_info.busy_workers_count == 1
-      assert length(debug_info.waiting_callers) == 0
+      assert Enum.empty?(debug_info.waiting_callers)
 
       [new_worker_pid] = debug_info.busy_workers_pids
 


### PR DESCRIPTION
Fixed a bug where a restarted worker was not automatically dispatched to pending callers.

Additional improvements:
- Simplified code by removing the `temporary_worker` conception.
- Prevented possible memory leaks by changing workers `restart` strategy to `temporary`.

Closes #53 