### PR TITLE
Handling caller's death

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a bug with workers stuck in busy status. Added caller monitoring. [PR](https://github.com/general-CbIC/poolex/pull/56)
+
 ## [0.7.5] - 2023-07-31
 
 ### Fixed

--- a/lib/poolex.ex
+++ b/lib/poolex.ex
@@ -342,7 +342,7 @@ defmodule Poolex do
 
         {:reply, {:ok, new_worker}, %State{state | overflow: state.overflow + 1}}
       else
-        Monitoring.add(state.monitor_id, from_pid, :caller)
+        Monitoring.add(state.monitor_id, from_pid, :waiting_caller)
 
         new_callers_state =
           WaitingCallers.add(state.waiting_callers_impl, state.waiting_callers_state, caller)
@@ -406,8 +406,8 @@ defmodule Poolex do
       :worker ->
         {:noreply, handle_down_worker(state, dead_process_pid)}
 
-      :caller ->
-        {:noreply, handle_down_caller(state, dead_process_pid)}
+      :waiting_caller ->
+        {:noreply, handle_down_waiting_caller(state, dead_process_pid)}
     end
   end
 
@@ -517,8 +517,8 @@ defmodule Poolex do
     end
   end
 
-  @spec handle_down_caller(State.t(), pid()) :: State.t()
-  defp handle_down_caller(%State{} = state, dead_process_pid) do
+  @spec handle_down_waiting_caller(State.t(), pid()) :: State.t()
+  defp handle_down_waiting_caller(%State{} = state, dead_process_pid) do
     new_waiting_callers_state =
       WaitingCallers.remove_by_pid(
         state.waiting_callers_impl,

--- a/lib/poolex.ex
+++ b/lib/poolex.ex
@@ -204,7 +204,7 @@ defmodule Poolex do
     try do
       fun.(pid)
     after
-      Process.exit(monitor_process, :normal)
+      Process.exit(monitor_process, :kill)
       GenServer.cast(pool_id, {:release_busy_worker, pid})
     end
   end

--- a/lib/poolex.ex
+++ b/lib/poolex.ex
@@ -541,6 +541,7 @@ defmodule Poolex do
     :ok
   end
 
+  # Monitor the `caller`. Release attached worker in case of caller's death.
   @spec monitor_caller(pool_id(), caller :: pid(), worker :: pid()) :: :ok
   defp monitor_caller(pool_id, caller, worker) do
     spawn(fn ->

--- a/lib/poolex/monitoring.ex
+++ b/lib/poolex/monitoring.ex
@@ -1,7 +1,7 @@
 defmodule Poolex.Monitoring do
   @moduledoc false
   @type monitor_id() :: atom() | reference()
-  @type kind_of_process() :: :worker | :caller
+  @type kind_of_process() :: :worker | :waiting_caller
 
   @spec init(Poolex.pool_id()) :: {:ok, monitor_id()}
   @doc false

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -250,6 +250,7 @@ defmodule PoolexTest do
       :timer.sleep(10)
 
       debug_info = Poolex.get_debug_info(pool_name)
+
       assert debug_info.busy_workers_count == 1
       assert debug_info.idle_workers_count == 1
 

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -264,6 +264,33 @@ defmodule PoolexTest do
       assert debug_info.idle_workers_count == 2
     end
 
+    test "release busy worker when caller dies (overflow case)" do
+      pool_name = start_pool(worker_module: SomeWorker, workers_count: 0, max_overflow: 2)
+
+      caller =
+        spawn(fn ->
+          Poolex.run(pool_name, fn pid ->
+            GenServer.call(pid, {:do_some_work_with_delay, :timer.seconds(4)})
+          end)
+        end)
+
+      :timer.sleep(10)
+
+      debug_info = Poolex.get_debug_info(pool_name)
+
+      assert debug_info.busy_workers_count == 1
+      assert debug_info.idle_workers_count == 0
+
+      Process.exit(caller, :kill)
+
+      :timer.sleep(10)
+
+      debug_info = Poolex.get_debug_info(pool_name)
+
+      assert debug_info.busy_workers_count == 0
+      assert debug_info.idle_workers_count == 0
+    end
+
     test "runtime errors" do
       pool_name = start_pool(worker_module: SomeWorker, workers_count: 1)
       Poolex.run(pool_name, fn pid -> GenServer.call(pid, :do_raise) end)


### PR DESCRIPTION
In this PR, I have fixed a trouble mentioned in #51. Previously, if a caller died, Poolex knew nothing about it, and the busy worker remained active.

Also refactored monitoring naming. To be more honest, `:caller` changed to `:waiting_caller`.
