### PR TITLE
Handle checkout timeout correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Poolex.caller()` type replaced with struct defined in `Poolex.Caller.t()`.
   - Reason: We need to save uniq caller reference.
 
+### Fixed
+
+- Fixed a bug when workers get stuck in `busy` status after checkout timeout.
+
 ## [0.7.6] - 2023-08-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Poolex.run/3` returns tuple `{:error, :checkout_timeout}` instead of `:all_workers_are_busy`.
   - Reason: It is easier to understand the uniform format of the response from the function: `{:ok, result}` or `{:error, reason}`.
+- `Poolex.caller()` type replaced with struct defined in `Poolex.Caller.t()`.
+  - Reason: We need to save uniq caller reference.
 
 ## [0.7.6] - 2023-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+#### Breaking changes
+
+- Option `:timeout` renamed to `:checkout_timeout`.
+  - Reason: This option configures only the waiting time for `worker` from the pool, not the task's work time. This naming should be more understandable on the call site.
+
+    ```elixir
+    # Before
+    Poolex.run(:my_awesome_pool, fn worker -> some_work(worker) end, timeout: 10_000)
+
+    # After
+    Poolex.run(:my_awesome_pool, fn worker -> some_work(worker) end, checkout_timeout: 10_000)
+    ```
+
 ## [0.7.6] - 2023-08-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     Poolex.run(:my_awesome_pool, fn worker -> some_work(worker) end, checkout_timeout: 10_000)
     ```
 
-- `Poolex.run/3` returns tuple `{:error, :checkout_timeout}` instead of `:all_workers_are_busy`.
+- `Poolex.run/3` returns tuple `{:error, :checkout_timeout}` instead of `:all_workers_are_busy`. Also `{:runtime_error, reason}` moved to `{:error, {:runtime_error, reason}}`.
   - Reason: It is easier to understand the uniform format of the response from the function: `{:ok, result}` or `{:error, reason}`.
 - `Poolex.caller()` type replaced with struct defined in `Poolex.Caller.t()`.
   - Reason: We need to save uniq caller reference.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     Poolex.run(:my_awesome_pool, fn worker -> some_work(worker) end, checkout_timeout: 10_000)
     ```
 
+- `Poolex.run/3` returns tuple `{:error, :checkout_timeout}` instead of `:all_workers_are_busy`.
+  - Reason: It is easier to understand the uniform format of the response from the function: `{:ok, result}` or `{:error, reason}`.
+
 ## [0.7.6] - 2023-08-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Supervisor.start_link(children, strategy: :one_for_one)
 Then you can execute any code on the workers with `run/3`:
 
 ```elixir
-iex> Poolex.run(:worker_pool, &(is_pid?(&1)), timeout: 1_000)
+iex> Poolex.run(:worker_pool, &(is_pid?(&1)), checkout_timeout: 1_000)
 {:ok, true}
 ```
 

--- a/docs/guides/example-of-use.cheatmd
+++ b/docs/guides/example-of-use.cheatmd
@@ -79,7 +79,7 @@ defmodule PoolexExample.Test do
               :ok
           end
         end,
-        timeout: @timeout
+        checkout_timeout: @timeout
       )
     end)
   end

--- a/docs/guides/getting-started.cheatmd
+++ b/docs/guides/getting-started.cheatmd
@@ -46,7 +46,7 @@ The first argument is the name of the pool mentioned above.
 
 The second argument is the function that takes the pid of the worker as the only parameter and performs the necessary actions.
 
-The third argument contains run options. Currently, there is only one `timeout` option that tells Poolex how long we can wait for a worker on the call site.
+The third argument contains run options. Currently, there is only one `checkout_timeout` option that tells Poolex how long we can wait for a worker on the call site.
 
 ```elixir
 iex> Poolex.start_link(pool_id: :agent_pool, worker_module: Agent, worker_args: [fn -> 5 end], workers_count: 1)

--- a/docs/guides/migration-from-poolboy.cheatmd
+++ b/docs/guides/migration-from-poolboy.cheatmd
@@ -67,6 +67,6 @@ If you want a safe interface with error handling, then use `run/3`.
 +  Poolex.run!(
 +    :some_pool,
 +    fn pid -> some_function(pid) end,
-+    timeout: :timer.seconds(10)
++    checkout_timeout: :timer.seconds(10)
 +  )
 ```

--- a/examples/poolex_example/lib/poolex_example/test.ex
+++ b/examples/poolex_example/lib/poolex_example/test.ex
@@ -20,7 +20,7 @@ defmodule PoolexExample.Test do
               :ok
           end
         end,
-        timeout: @timeout
+        checkout_timeout: @timeout
       )
     end)
   end

--- a/lib/poolex.ex
+++ b/lib/poolex.ex
@@ -158,7 +158,7 @@ defmodule Poolex do
 
   Returns:
     * `{:runtime_error, reason}` on errors.
-    * `:all_workers_are_busy` if no free worker was found before the timeout.
+    * `{:error, :checkout_timeout}` if no free worker was found before the timeout.
 
   See `run!/3` for more information.
 
@@ -171,13 +171,13 @@ defmodule Poolex do
       {:ok, 5}
   """
   @spec run(pool_id(), (worker :: pid() -> any()), list(run_option())) ::
-          {:ok, any()} | :all_workers_are_busy | {:runtime_error, any()}
+          {:ok, any()} | {:error, :checkout_timeout} | {:runtime_error, any()}
   def run(pool_id, fun, options \\ []) do
     {:ok, run!(pool_id, fun, options)}
   rescue
     runtime_error -> {:runtime_error, runtime_error}
   catch
-    :exit, {:timeout, _meta} -> :all_workers_are_busy
+    :exit, {:timeout, _meta} -> {:error, :checkout_timeout}
     :exit, reason -> {:runtime_error, reason}
   end
 

--- a/lib/poolex.ex
+++ b/lib/poolex.ex
@@ -18,7 +18,7 @@ defmodule Poolex do
   Then you can execute any code on the workers with `run/3`:
 
   ```elixir
-  Poolex.run(:worker_pool, &(is_pid?(&1)), timeout: 1_000)
+  Poolex.run(:worker_pool, &(is_pid?(&1)), checkout_timeout: 1_000)
   {:ok, true}
   ```
 
@@ -34,7 +34,7 @@ defmodule Poolex do
   alias Poolex.Private.State
   alias Poolex.Private.WaitingCallers
 
-  @default_wait_timeout :timer.seconds(5)
+  @default_checkout_timeout :timer.seconds(5)
   @poolex_options_table """
   | Option                 | Description                                          | Example               | Default value                     |
   |------------------------|------------------------------------------------------|-----------------------|-----------------------------------|
@@ -82,11 +82,11 @@ defmodule Poolex do
   @type caller() :: GenServer.from()
 
   @typedoc """
-  | Option  | Description                                        | Example  | Default value              |
-  |---------|----------------------------------------------------|----------|----------------------------|
-  | timeout | How long we can wait for a worker on the call site | `60_000` | `#{@default_wait_timeout}` |
+  | Option  | Description                                        | Example  | Default value                           |
+  |---------|----------------------------------------------------|----------|-----------------------------------------|
+  | checkout_timeout | How long we can wait for a worker on the call site | `60_000` | `#{@default_checkout_timeout}` |
   """
-  @type run_option() :: {:timeout, timeout()}
+  @type run_option() :: {:checkout_timeout, timeout()}
 
   @doc """
   Starts a Poolex process without links (outside of a supervision tree).
@@ -195,9 +195,9 @@ defmodule Poolex do
   """
   @spec run!(pool_id(), (worker :: pid() -> any()), list(run_option())) :: any()
   def run!(pool_id, fun, options \\ []) do
-    timeout = Keyword.get(options, :timeout, @default_wait_timeout)
+    checkout_timeout = Keyword.get(options, :checkout_timeout, @default_checkout_timeout)
 
-    {:ok, pid} = GenServer.call(pool_id, :get_idle_worker, timeout)
+    {:ok, pid} = GenServer.call(pool_id, :get_idle_worker, checkout_timeout)
 
     monitor_process = monitor_caller(pool_id, self(), pid)
 

--- a/lib/poolex/caller.ex
+++ b/lib/poolex/caller.ex
@@ -1,0 +1,15 @@
+defmodule Poolex.Caller do
+  @moduledoc """
+  Caller structure.
+
+  **Callers** are processes that have requested to get a worker.
+  """
+
+  defstruct from: nil,
+            reference: nil
+
+  @type t() :: %__MODULE__{
+          from: GenServer.from(),
+          reference: reference()
+        }
+end

--- a/lib/poolex/callers/behaviour.ex
+++ b/lib/poolex/callers/behaviour.ex
@@ -12,13 +12,13 @@ defmodule Poolex.Callers.Behaviour do
   @doc "Returns `state` (any data structure) which will be passed as the first argument to all other functions."
   @callback init() :: state()
   @doc "Adds caller to `state` and returns new state."
-  @callback add(state(), Poolex.caller()) :: state()
+  @callback add(state(), Poolex.Caller.t()) :: state()
   @doc "Returns `true` if the `state` is empty, `false` otherwise."
   @callback empty?(state()) :: boolean()
   @doc "Removes one of callers from `state` and returns it as `{caller, state}`. Returns `:empty` if state is empty."
-  @callback pop(state()) :: {Poolex.caller(), state()} | :empty
+  @callback pop(state()) :: {Poolex.Caller.t(), state()} | :empty
   @doc "Removes given caller by caller's pid from `state` and returns new state."
   @callback remove_by_pid(state(), caller_pid :: pid()) :: state()
   @doc "Returns list of callers."
-  @callback to_list(state()) :: list(Poolex.caller())
+  @callback to_list(state()) :: list(Poolex.Caller.t())
 end

--- a/lib/poolex/callers/behaviour.ex
+++ b/lib/poolex/callers/behaviour.ex
@@ -17,8 +17,10 @@ defmodule Poolex.Callers.Behaviour do
   @callback empty?(state()) :: boolean()
   @doc "Removes one of callers from `state` and returns it as `{caller, state}`. Returns `:empty` if state is empty."
   @callback pop(state()) :: {Poolex.Caller.t(), state()} | :empty
-  @doc "Removes given caller by caller's pid from `state` and returns new state."
+  @doc "Removes caller by pid from `state` and returns new state."
   @callback remove_by_pid(state(), caller_pid :: pid()) :: state()
+  @doc "Removes caller by reference from `state` and returns new state."
+  @callback remove_by_reference(state(), reference :: reference()) :: state()
   @doc "Returns list of callers."
   @callback to_list(state()) :: list(Poolex.Caller.t())
 end

--- a/lib/poolex/callers/impl/erlang_queue.ex
+++ b/lib/poolex/callers/impl/erlang_queue.ex
@@ -33,6 +33,14 @@ defmodule Poolex.Callers.Impl.ErlangQueue do
   end
 
   @impl true
+  def remove_by_reference(state, caller_reference) do
+    :queue.filter(
+      fn %Poolex.Caller{reference: reference} -> reference != caller_reference end,
+      state
+    )
+  end
+
+  @impl true
   def to_list(state) do
     :queue.to_list(state)
   end

--- a/lib/poolex/callers/impl/erlang_queue.ex
+++ b/lib/poolex/callers/impl/erlang_queue.ex
@@ -29,7 +29,7 @@ defmodule Poolex.Callers.Impl.ErlangQueue do
 
   @impl true
   def remove_by_pid(state, caller_pid) do
-    :queue.filter(fn {pid, _} -> pid != caller_pid end, state)
+    :queue.filter(fn %Poolex.Caller{from: {pid, _tag}} -> pid != caller_pid end, state)
   end
 
   @impl true

--- a/lib/poolex/checkout_timeout_error.ex
+++ b/lib/poolex/checkout_timeout_error.ex
@@ -1,3 +1,7 @@
 defmodule Poolex.CheckoutTimeoutError do
+  @moduledoc """
+  Raised on using `Poolex.run!/3` when a checkout times out.
+  """
+
   defexception message: "checkout timeout"
 end

--- a/lib/poolex/checkout_timeout_error.ex
+++ b/lib/poolex/checkout_timeout_error.ex
@@ -1,0 +1,3 @@
+defmodule Poolex.CheckoutTimeoutError do
+  defexception message: "checkout timeout"
+end

--- a/lib/poolex/private/waiting_callers.ex
+++ b/lib/poolex/private/waiting_callers.ex
@@ -48,6 +48,18 @@ defmodule Poolex.Private.WaitingCallers do
   end
 
   @doc false
+  @spec remove_by_reference(State.t(), reference :: reference()) :: State.t()
+  def remove_by_reference(
+        %State{waiting_callers_impl: impl, waiting_callers_state: waiting_callers_state} = state,
+        reference
+      ) do
+    %State{
+      state
+      | waiting_callers_state: impl.remove_by_reference(waiting_callers_state, reference)
+    }
+  end
+
+  @doc false
   @spec to_list(State.t()) :: list(Poolex.Caller.t())
   def to_list(%State{waiting_callers_impl: impl, waiting_callers_state: state}) do
     impl.to_list(state)

--- a/lib/poolex/private/waiting_callers.ex
+++ b/lib/poolex/private/waiting_callers.ex
@@ -10,7 +10,7 @@ defmodule Poolex.Private.WaitingCallers do
   end
 
   @doc false
-  @spec add(State.t(), Poolex.caller()) :: State.t()
+  @spec add(State.t(), Poolex.Caller.t()) :: State.t()
   def add(
         %State{waiting_callers_impl: impl, waiting_callers_state: waiting_callers_state} = state,
         caller
@@ -25,7 +25,7 @@ defmodule Poolex.Private.WaitingCallers do
   end
 
   @doc false
-  @spec pop(State.t()) :: {Poolex.caller(), State.t()} | :empty
+  @spec pop(State.t()) :: {Poolex.Caller.t(), State.t()} | :empty
   def pop(
         %State{waiting_callers_impl: impl, waiting_callers_state: waiting_callers_state} = state
       ) do
@@ -48,7 +48,7 @@ defmodule Poolex.Private.WaitingCallers do
   end
 
   @doc false
-  @spec to_list(State.t()) :: list(Poolex.caller())
+  @spec to_list(State.t()) :: list(Poolex.Caller.t())
   def to_list(%State{waiting_callers_impl: impl, waiting_callers_state: state}) do
     impl.to_list(state)
   end

--- a/test/poolex/callers/impl/erlang_queue_test.exs
+++ b/test/poolex/callers/impl/erlang_queue_test.exs
@@ -37,6 +37,14 @@ defmodule Poolex.Callers.Impl.ErlangQueueTest do
       |> Impl.remove_by_pid(caller_1_pid)
 
     assert Impl.to_list(state) == [caller_2, caller_2]
+
+    # Remove by reference
+    state =
+      state
+      |> Impl.add(caller_1)
+      |> Impl.remove_by_reference(caller_2.reference)
+
+    assert Impl.to_list(state) == [caller_1]
   end
 
   defp gen_caller(pid, tag \\ make_ref()) do

--- a/test/poolex/callers/impl/erlang_queue_test.exs
+++ b/test/poolex/callers/impl/erlang_queue_test.exs
@@ -40,6 +40,9 @@ defmodule Poolex.Callers.Impl.ErlangQueueTest do
   end
 
   defp gen_caller(pid, tag \\ make_ref()) do
-    {pid, tag}
+    %Poolex.Caller{
+      from: {pid, tag},
+      reference: make_ref()
+    }
   end
 end

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -350,17 +350,17 @@ defmodule PoolexTest do
       assert result == {:error, :checkout_timeout}
     end
 
-    test "run!/3 exits on timeout" do
+    test "run!/3 raises an error on checkout timeout" do
       pool_name = start_pool(worker_module: SomeWorker, workers_count: 1)
       launch_long_task(pool_name)
 
-      assert catch_exit(
+      assert catch_error(
                Poolex.run!(
                  pool_name,
                  fn pid -> GenServer.call(pid, {:do_some_work_with_delay, :timer.seconds(4)}) end,
                  checkout_timeout: 100
                )
-             ) == {:timeout, {GenServer, :call, [pool_name, :get_idle_worker, 100]}}
+             ) == %Poolex.CheckoutTimeoutError{message: "checkout timeout"}
     end
   end
 

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -336,7 +336,7 @@ defmodule PoolexTest do
       assert Enum.empty?(debug_info.waiting_callers)
     end
 
-    test "run/3 returns :all_workers_are_busy on timeout" do
+    test "run/3 returns error on checkout timeout" do
       pool_name = start_pool(worker_module: SomeWorker, workers_count: 1)
       launch_long_task(pool_name)
 
@@ -347,7 +347,7 @@ defmodule PoolexTest do
           checkout_timeout: 100
         )
 
-      assert result == :all_workers_are_busy
+      assert result == {:error, :checkout_timeout}
     end
 
     test "run!/3 exits on timeout" do
@@ -387,7 +387,7 @@ defmodule PoolexTest do
           checkout_timeout: 100
         )
 
-      assert result == :all_workers_are_busy
+      assert result == {:error, :checkout_timeout}
 
       debug_info = Poolex.get_debug_info(pool_name)
 

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -318,7 +318,7 @@ defmodule PoolexTest do
             fn pid ->
               GenServer.call(pid, {:do_some_work_with_delay, :timer.seconds(4)})
             end,
-            timeout: 100
+            checkout_timeout: 100
           )
         end)
 
@@ -344,7 +344,7 @@ defmodule PoolexTest do
         Poolex.run(
           pool_name,
           fn pid -> GenServer.call(pid, {:do_some_work_with_delay, :timer.seconds(4)}) end,
-          timeout: 100
+          checkout_timeout: 100
         )
 
       assert result == :all_workers_are_busy
@@ -358,7 +358,7 @@ defmodule PoolexTest do
                Poolex.run!(
                  pool_name,
                  fn pid -> GenServer.call(pid, {:do_some_work_with_delay, :timer.seconds(4)}) end,
-                 timeout: 100
+                 checkout_timeout: 100
                )
              ) == {:timeout, {GenServer, :call, [pool_name, :get_idle_worker, 100]}}
     end
@@ -384,7 +384,7 @@ defmodule PoolexTest do
         Poolex.run(
           pool_name,
           fn pid -> GenServer.call(pid, {:do_some_work_with_delay, :timer.seconds(4)}) end,
-          timeout: 100
+          checkout_timeout: 100
         )
 
       assert result == :all_workers_are_busy
@@ -543,7 +543,7 @@ defmodule PoolexTest do
         Poolex.run(
           pool_id,
           fn pid -> GenServer.call(pid, {:do_some_work_with_delay, delay}) end,
-          timeout: 100
+          checkout_timeout: 100
         )
       end)
     end

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -351,10 +351,7 @@ defmodule PoolexTest do
 
       :timer.sleep(10)
 
-      debug_info = Poolex.get_debug_info(pool_name) |> dbg()
-
-      assert debug_info.busy_workers_count == 0
-      assert debug_info.idle_workers_count == 1
+      debug_info = Poolex.get_debug_info(pool_name)
       assert Enum.count(debug_info.waiting_callers) == 0
     end
 
@@ -373,9 +370,6 @@ defmodule PoolexTest do
       :timer.sleep(10)
 
       debug_info = Poolex.get_debug_info(pool_name)
-
-      assert debug_info.busy_workers_count == 0
-      assert debug_info.idle_workers_count == 1
       assert Enum.count(debug_info.waiting_callers) == 0
     end
   end

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -222,7 +222,7 @@ defmodule PoolexTest do
       debug_info = Poolex.get_debug_info(pool_name)
       assert length(debug_info.waiting_callers) == 10
 
-      assert Enum.find(debug_info.waiting_callers, fn {pid, _} ->
+      assert Enum.find(debug_info.waiting_callers, fn %Poolex.Caller{from: {pid, _tag}} ->
                pid == waiting_caller
              end)
 
@@ -232,7 +232,7 @@ defmodule PoolexTest do
       debug_info = Poolex.get_debug_info(pool_name)
       assert length(debug_info.waiting_callers) == 9
 
-      refute Enum.find(debug_info.waiting_callers, fn {pid, _} ->
+      refute Enum.find(debug_info.waiting_callers, fn %Poolex.Caller{from: {pid, _tag}} ->
                pid == waiting_caller
              end)
     end
@@ -327,7 +327,7 @@ defmodule PoolexTest do
       debug_info = Poolex.get_debug_info(pool_name)
       assert length(debug_info.waiting_callers) == 1
 
-      assert Enum.find(debug_info.waiting_callers, fn {pid, _} ->
+      assert Enum.find(debug_info.waiting_callers, fn %Poolex.Caller{from: {pid, _tag}} ->
                pid == waiting_caller
              end)
 
@@ -348,6 +348,14 @@ defmodule PoolexTest do
         )
 
       assert result == {:error, :checkout_timeout}
+
+      :timer.sleep(10)
+
+      debug_info = Poolex.get_debug_info(pool_name) |> dbg()
+
+      assert debug_info.busy_workers_count == 0
+      assert debug_info.idle_workers_count == 1
+      assert Enum.count(debug_info.waiting_callers) == 0
     end
 
     test "run!/3 raises an error on checkout timeout" do
@@ -361,6 +369,14 @@ defmodule PoolexTest do
                  checkout_timeout: 100
                )
              ) == %Poolex.CheckoutTimeoutError{message: "checkout timeout"}
+
+      :timer.sleep(10)
+
+      debug_info = Poolex.get_debug_info(pool_name)
+
+      assert debug_info.busy_workers_count == 0
+      assert debug_info.idle_workers_count == 1
+      assert Enum.count(debug_info.waiting_callers) == 0
     end
   end
 

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -386,8 +386,9 @@ defmodule PoolexTest do
                  GenServer.call(pid, {:do_some_work_with_delay, delay}, 1000)
                end)
 
-      assert {:runtime_error,
-              {:timeout, {GenServer, :call, [_pid, {:do_some_work_with_delay, ^delay}, 1]}}} =
+      assert {:error,
+              {:runtime_error,
+               {:timeout, {GenServer, :call, [_pid, {:do_some_work_with_delay, ^delay}, 1]}}}} =
                Poolex.run(pool_name, fn pid ->
                  GenServer.call(pid, {:do_some_work_with_delay, delay}, 1)
                end)

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -354,7 +354,7 @@ defmodule PoolexTest do
       :timer.sleep(10)
 
       debug_info = Poolex.get_debug_info(pool_name)
-      assert Enum.count(debug_info.waiting_callers) == 0
+      assert Enum.empty?(debug_info.waiting_callers)
       assert debug_info.busy_workers_count == 1
       assert debug_info.idle_workers_count == 0
     end
@@ -374,7 +374,7 @@ defmodule PoolexTest do
       :timer.sleep(10)
 
       debug_info = Poolex.get_debug_info(pool_name)
-      assert Enum.count(debug_info.waiting_callers) == 0
+      assert Enum.empty?(debug_info.waiting_callers)
     end
 
     test "handle worker's timout" do

--- a/test/support/some_waiting_callers_impl.ex
+++ b/test/support/some_waiting_callers_impl.ex
@@ -27,7 +27,15 @@ defmodule SomeWaitingCallersImpl do
 
   @impl true
   def remove_by_pid(state, caller_pid) do
-    :queue.filter(fn {pid, _} -> pid != caller_pid end, state)
+    :queue.filter(fn %Poolex.Caller{from: {pid, _tag}} -> pid != caller_pid end, state)
+  end
+
+  @impl true
+  def remove_by_reference(state, caller_reference) do
+    :queue.filter(
+      fn %Poolex.Caller{reference: reference} -> reference != caller_reference end,
+      state
+    )
   end
 
   @impl true


### PR DESCRIPTION
### Changed

#### Breaking changes

- Option `:timeout` renamed to `:checkout_timeout`.
  - Reason: This option configures only the waiting time for `worker` from the pool, not the task's work time. This naming should be more understandable on the call site.

    ```elixir
    # Before
    Poolex.run(:my_awesome_pool, fn worker -> some_work(worker) end, timeout: 10_000)

    # After
    Poolex.run(:my_awesome_pool, fn worker -> some_work(worker) end, checkout_timeout: 10_000)
    ```

- `Poolex.run/3` returns tuple `{:error, :checkout_timeout}` instead of `:all_workers_are_busy`. Also `{:runtime_error, reason}` moved to `{:error, {:runtime_error, reason}}`.
  - Reason: It is easier to understand the uniform format of the response from the function: `{:ok, result}` or `{:error, reason}`.
- `Poolex.caller()` type replaced with struct defined in `Poolex.Caller.t()`.
  - Reason: We need to save uniq caller reference.

### Fixed

- Fixed a bug when workers get stuck in `busy` status after checkout timeout.

---
Closes #51 