### PR TITLE
Merge `run` interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     Poolex.run(:my_awesome_pool, fn worker -> some_work(worker) end, checkout_timeout: 10_000)
     ```
 
-- `Poolex.run/3` returns tuple `{:error, :checkout_timeout}` instead of `:all_workers_are_busy`. Also `{:runtime_error, reason}` moved to `{:error, {:runtime_error, reason}}`.
+- `Poolex.run/3` returns tuple `{:error, :checkout_timeout}` instead of `:all_workers_are_busy`.
   - Reason: It is easier to understand the uniform format of the response from the function: `{:ok, result}` or `{:error, reason}`.
 - `Poolex.caller()` type replaced with struct defined in `Poolex.Caller.t()`.
-  - Reason: We need to save uniq caller reference.
+  - Reason: We need to save unique caller references.
+- `Poolex.run!/3` was removed in favor of `Poolex.run/3`. The new unified function returns `{:ok, result}` or `{:error, :checkout_timeout}` and not handles runtime errors anymore.
+  - Reason: We should not catch errors in the caller process. The caller process itself must choose how to handle exceptions and exit signals.
 
 ### Fixed
 

--- a/docs/guides/example-of-use.cheatmd
+++ b/docs/guides/example-of-use.cheatmd
@@ -65,7 +65,7 @@ defmodule PoolexExample.Test do
 
   defp async_call_square_root(i) do
     Task.async(fn ->
-      Poolex.run!(
+      Poolex.run(
         :worker_pool,
         fn pid ->
           # Let's wrap the genserver call in a try-catch block. This allows us to trap any exceptions

--- a/docs/guides/getting-started.cheatmd
+++ b/docs/guides/getting-started.cheatmd
@@ -40,7 +40,7 @@ The second argument should contain a set of options for starting the pool.
 
 ## Working with the pool
 
-After the pool is initialized, you can get a free worker and perform any operations on it. This is done through the main interfaces `run/3` and `run!/3`. The functions work the same and the only difference between them is that `run/3` takes care of the runtime error handling.
+After the pool is initialized, you can get a free worker and perform any operations on it. This is done through the main interface `run/3`.
 
 The first argument is the name of the pool mentioned above.
 
@@ -52,8 +52,6 @@ The third argument contains run options. Currently, there is only one `checkout_
 iex> Poolex.start_link(pool_id: :agent_pool, worker_module: Agent, worker_args: [fn -> 5 end], workers_count: 1)
 iex> Poolex.run(:agent_pool, fn pid -> Agent.get(pid, &(&1)) end)
 {:ok, 5}
-iex> Poolex.run!(:agent_pool, fn pid -> Agent.get(pid, &(&1)) end)
-5
 ```
 
 If you would like to see examples of using Poolex, then check out [Example of Use](https://hexdocs.pm/poolex/example-of-use.html).

--- a/docs/guides/migration-from-poolboy.cheatmd
+++ b/docs/guides/migration-from-poolboy.cheatmd
@@ -55,8 +55,8 @@ end
 
 ### III. Update call site
 
-Use `run!/3` to leave the same behavior. 
-If you want a safe interface with error handling, then use `run/3`.
+Use `run/3`.
+Be careful, unlike `:poolboy.transaction`, `Poolex.run` returns `{:ok, result}`.
 
 ```diff
 -  :poolboy.transaction(
@@ -64,7 +64,7 @@ If you want a safe interface with error handling, then use `run/3`.
 -    fn pid -> some_function(pid) end,
 -    :timer.seconds(10)
 -  )
-+  Poolex.run!(
++  Poolex.run(
 +    :some_pool,
 +    fn pid -> some_function(pid) end,
 +    checkout_timeout: :timer.seconds(10)

--- a/docs/guides/workers-and-callers-implementations.md
+++ b/docs/guides/workers-and-callers-implementations.md
@@ -4,7 +4,7 @@
 
 ## Callers
 
-`Callers` are processes that have requested to get a worker (used `run/3` or `run!/3`). Each pool keeps the information about `callers` to distribute workers to them when they are free.
+`Callers` are processes that have requested to get a worker (used `run/3`). Each pool keeps the information about `callers` to distribute workers to them when they are free.
 
 > ### Caller's typespec {: .warning}
 >

--- a/lib/poolex.ex
+++ b/lib/poolex.ex
@@ -190,7 +190,7 @@ defmodule Poolex do
   @spec run!(pool_id(), (worker :: pid() -> any()), list(run_option())) :: any()
   def run!(pool_id, fun, options \\ []) do
     checkout_timeout = Keyword.get(options, :checkout_timeout, @default_checkout_timeout)
-    worker_pid = get_idle_worker(pool_id, checkout_timeout)
+    {:ok, worker_pid} = get_idle_worker(pool_id, checkout_timeout)
     monitor_process = monitor_caller(pool_id, self(), worker_pid)
 
     try do
@@ -201,7 +201,7 @@ defmodule Poolex do
     end
   end
 
-  @spec get_idle_worker(pool_id(), timeout()) :: worker()
+  @spec get_idle_worker(pool_id(), timeout()) :: {:ok, worker()}
   defp get_idle_worker(pool_id, checkout_timeout) do
     caller_reference = make_ref()
     GenServer.call(pool_id, {:get_idle_worker, caller_reference}, checkout_timeout)
@@ -349,7 +349,7 @@ defmodule Poolex do
 
         state = BusyWorkers.add(state, new_worker)
 
-        {:reply, new_worker, %State{state | overflow: state.overflow + 1}}
+        {:reply, {:ok, new_worker}, %State{state | overflow: state.overflow + 1}}
       else
         Monitoring.add(state.monitor_id, from_pid, :waiting_caller)
 
@@ -362,7 +362,7 @@ defmodule Poolex do
       {idle_worker_pid, state} = IdleWorkers.pop(state)
       state = BusyWorkers.add(state, idle_worker_pid)
 
-      {:reply, idle_worker_pid, state}
+      {:reply, {:ok, idle_worker_pid}, state}
     end
   end
 
@@ -441,7 +441,7 @@ defmodule Poolex do
   defp provide_worker_to_waiting_caller(%State{} = state, worker) do
     {caller, state} = WaitingCallers.pop(state)
 
-    GenServer.reply(caller.from, worker)
+    GenServer.reply(caller.from, {:ok, worker})
 
     state
   end

--- a/lib/poolex/checkout_timeout_error.ex
+++ b/lib/poolex/checkout_timeout_error.ex
@@ -1,7 +1,0 @@
-defmodule Poolex.CheckoutTimeoutError do
-  @moduledoc """
-  Raised on using `Poolex.run!/3` when a checkout times out.
-  """
-
-  defexception message: "checkout timeout"
-end


### PR DESCRIPTION
Improvements based on review comments from #59

`Poolex.run!/3` was removed in favor of `Poolex.run/3`. The new unified function returns `{:ok, result}` or `{:error, :checkout_timeout}` and not handles runtime errors anymore.
  - Reason: We should not catch errors in the caller process. The caller process itself must choose how to handle exceptions and exit signals.