### PR TITLE
Support true GenServer naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Monitoring implementation now uses `Agent` instead of `:ets`. It's needed to be more flexible in pool naming.
+- The `pool_id` can now be any valid `GenServer.name()`. For example, `{:global, :biba}` or `{:via, Registry, {MyRegistry, "boba"}}`.
 
 ## [0.10.0] - 2024-08-26
 

--- a/lib/poolex.ex
+++ b/lib/poolex.ex
@@ -52,9 +52,10 @@ defmodule Poolex do
   """
 
   @typedoc """
-  Any atom naming your pool, e.g. `:my_pool`.
+  Any valid GenServer's name. It may be an atom like `:some_pool` or a tuple {:via, Registry, {MyApp.Registry, "pool"}
+  if you want to use Registry.
   """
-  @type pool_id() :: atom()
+  @type pool_id() :: GenServer.name()
   @typedoc """
   #{@poolex_options_table}
   """


### PR DESCRIPTION
The `pool_id` can now be any valid `GenServer.name()`. For example, `{:global, :biba}` or `{:via, Registry, {MyRegistry, "boba"}}`.

Fixes #99 