### PR TITLE
Use ExUnit parameterize feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added Elixir 1.18.* support to CI.
 
+### Changed
+
+- Refactored tests with new [ExUnit parameterize feature](https://hexdocs.pm/ex_unit/1.18.0/ExUnit.Case.html#module-parameterized-tests).
+
+### Fixed
+
+- The functions `Poolex.add_idle_workers!/2` and `Poolex.remove_idle_workers!/2` now accept any value of type `GenServer.name()` as their first argument, instead of only `atom()`.
+
 ## [1.1.0] - 2024-12-08
 
 ### Added

--- a/lib/poolex.ex
+++ b/lib/poolex.ex
@@ -55,7 +55,7 @@ defmodule Poolex do
   Any valid GenServer's name. It may be an atom like `:some_pool` or a tuple {:via, Registry, {MyApp.Registry, "pool"}
   if you want to use Registry.
   """
-  @type pool_id() :: GenServer.name()
+  @type pool_id() :: GenServer.name() | pid()
   @typedoc """
   #{@poolex_options_table}
   """

--- a/lib/poolex.ex
+++ b/lib/poolex.ex
@@ -252,7 +252,7 @@ defmodule Poolex do
     raise ArgumentError, message
   end
 
-  def add_idle_workers!(pool_id, workers_count) when is_atom(pool_id) and is_integer(workers_count) do
+  def add_idle_workers!(pool_id, workers_count) when is_integer(workers_count) do
     GenServer.call(pool_id, {:add_idle_workers, workers_count})
   end
 
@@ -267,7 +267,7 @@ defmodule Poolex do
     raise ArgumentError, message
   end
 
-  def remove_idle_workers!(pool_id, workers_count) when is_atom(pool_id) and is_integer(workers_count) do
+  def remove_idle_workers!(pool_id, workers_count) when is_integer(workers_count) do
     GenServer.call(pool_id, {:remove_idle_workers, workers_count})
   end
 

--- a/test/poolex_metrics_test.exs
+++ b/test/poolex_metrics_test.exs
@@ -7,13 +7,15 @@ defmodule PoolexMetricsTest do
 
   @tag telemetry_events: [[:poolex, :metrics, :pool_size]]
   test "pool size metrics" do
-    pool_id =
-      start_pool(
-        worker_module: SomeWorker,
-        workers_count: 5,
-        pool_size_metrics: true,
-        max_overflow: 5
-      )
+    pool_id = SomeWorker
+
+    start_pool(
+      pool_id: pool_id,
+      worker_module: SomeWorker,
+      workers_count: 5,
+      pool_size_metrics: true,
+      max_overflow: 5
+    )
 
     assert_telemetry_event(
       [:poolex, :metrics, :pool_size],

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -702,36 +702,4 @@ defmodule PoolexTest do
       end)
     end
   end
-
-  describe "using GenServer.name() naming" do
-    test "works with {:global, term()}" do
-      ExUnit.Callbacks.start_supervised(
-        {Poolex,
-         [
-           pool_id: {:global, :biba},
-           worker_module: SomeWorker,
-           workers_count: 5
-         ]}
-      )
-
-      state = :sys.get_state({:global, :biba})
-
-      assert state.pool_id == {:global, :biba}
-
-      assert {:ok, true} == Poolex.run({:global, :biba}, &is_pid/1)
-    end
-
-    test "works with Registry" do
-      ExUnit.Callbacks.start_supervised({Registry, [keys: :unique, name: TestRegistry]})
-      name = {:via, Registry, {TestRegistry, "pool"}}
-
-      ExUnit.Callbacks.start_supervised({Poolex, [pool_id: name, worker_module: SomeWorker, workers_count: 5]})
-
-      state = :sys.get_state(name)
-
-      assert state.pool_id == name
-
-      assert {:ok, true} == Poolex.run(name, &is_pid/1)
-    end
-  end
 end

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -674,30 +674,24 @@ defmodule PoolexTest do
   end
 
   describe "remove_idle_workers!/2" do
-    test "removes idle workers from pool" do
-      initial_fun = fn -> 0 end
-
-      pool_name = start_pool(worker_module: Agent, worker_args: [initial_fun], workers_count: 5)
+    test "removes idle workers from pool", %{pool_options: pool_options} do
+      pool_name = start_pool(pool_options)
 
       assert %DebugInfo{idle_workers_count: 5} = Poolex.get_debug_info(pool_name)
       assert :ok = Poolex.remove_idle_workers!(pool_name, 2)
       assert %DebugInfo{idle_workers_count: 3} = Poolex.get_debug_info(pool_name)
     end
 
-    test "removes all idle workers when argument is bigger than idle_workers count" do
-      initial_fun = fn -> 0 end
-
-      pool_name = start_pool(worker_module: Agent, worker_args: [initial_fun], workers_count: 3)
+    test "removes all idle workers when argument is bigger than idle_workers count", %{pool_options: pool_options} do
+      pool_name = pool_options |> Keyword.put(:workers_count, 3) |> start_pool()
 
       assert %DebugInfo{idle_workers_count: 3} = Poolex.get_debug_info(pool_name)
       assert :ok = Poolex.remove_idle_workers!(pool_name, 5)
       assert %DebugInfo{idle_workers_count: 0} = Poolex.get_debug_info(pool_name)
     end
 
-    test "raises error on non positive workers_count" do
-      initial_fun = fn -> 0 end
-
-      pool_name = start_pool(worker_module: Agent, worker_args: [initial_fun], workers_count: 5)
+    test "raises error on non positive workers_count", %{pool_options: pool_options} do
+      pool_name = start_pool(pool_options)
 
       assert_raise(ArgumentError, fn ->
         Poolex.remove_idle_workers!(pool_name, -1)

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -336,8 +336,11 @@ defmodule PoolexTest do
   end
 
   describe "timeouts" do
-    test "when caller waits too long" do
-      pool_name = start_pool(worker_module: SomeWorker, workers_count: 1)
+    test "when caller waits too long", %{pool_options: pool_options} do
+      pool_name =
+        pool_options
+        |> Keyword.put(:workers_count, 1)
+        |> start_pool()
 
       launch_long_task(pool_name)
 
@@ -368,8 +371,12 @@ defmodule PoolexTest do
       assert debug_info.idle_workers_count == 0
     end
 
-    test "run/3 returns error on checkout timeout" do
-      pool_name = start_pool(worker_module: SomeWorker, workers_count: 1)
+    test "run/3 returns error on checkout timeout", %{pool_options: pool_options} do
+      pool_name =
+        pool_options
+        |> Keyword.put(:workers_count, 1)
+        |> start_pool()
+
       launch_long_task(pool_name)
 
       result =
@@ -389,8 +396,12 @@ defmodule PoolexTest do
       assert debug_info.idle_workers_count == 0
     end
 
-    test "handle worker's timeout" do
-      pool_name = start_pool(worker_module: SomeWorker, workers_count: 1)
+    test "handle worker's timeout", %{pool_options: pool_options} do
+      pool_name =
+        pool_options
+        |> Keyword.put(:workers_count, 1)
+        |> start_pool()
+
       delay = 100
 
       assert {:ok, :some_result} =
@@ -406,9 +417,14 @@ defmodule PoolexTest do
                )
     end
 
-    test "worker not hangs in busy status after checkout timeout" do
+    test "worker not hangs in busy status after checkout timeout", %{pool_options: pool_options} do
       test_pid = self()
-      pool_name = start_pool(worker_module: SomeWorker, workers_count: 1)
+
+      pool_name =
+        pool_options
+        |> Keyword.put(:workers_count, 1)
+        |> start_pool()
+
       delay = 100
 
       process_1 =

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -16,6 +16,14 @@ defmodule PoolexTest do
 
   alias Poolex.Private.DebugInfo
 
+  setup do
+    if Version.match?(System.version(), ">= 1.18.0") do
+      []
+    else
+      [pool_options: [pool_id: SomeWorker, worker_module: SomeWorker, workers_count: 5]]
+    end
+  end
+
   doctest Poolex
 
   describe "debug info" do

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -474,8 +474,11 @@ defmodule PoolexTest do
   end
 
   describe "overflow" do
-    test "create new workers when possible" do
-      pool_name = start_pool(worker_module: SomeWorker, workers_count: 1, max_overflow: 5)
+    test "create new workers when possible", %{pool_options: pool_options} do
+      pool_name =
+        pool_options
+        |> Keyword.merge(workers_count: 1, max_overflow: 5)
+        |> start_pool()
 
       launch_long_tasks(pool_name, 5)
 
@@ -485,8 +488,12 @@ defmodule PoolexTest do
       assert debug_info.overflow == 4
     end
 
-    test "return error when max count of workers reached" do
-      pool_name = start_pool(worker_module: SomeWorker, workers_count: 1)
+    test "return error when max count of workers reached", %{pool_options: pool_options} do
+      pool_name =
+        pool_options
+        |> Keyword.put(:workers_count, 1)
+        |> start_pool()
+
       launch_long_task(pool_name)
 
       result =
@@ -505,8 +512,11 @@ defmodule PoolexTest do
       assert debug_info.overflow == 0
     end
 
-    test "all workers running over the limit are turned off after use" do
-      pool_name = start_pool(worker_module: SomeWorker, workers_count: 1, max_overflow: 2)
+    test "all workers running over the limit are turned off after use", %{pool_options: pool_options} do
+      pool_name =
+        pool_options
+        |> Keyword.merge(workers_count: 1, max_overflow: 2)
+        |> start_pool()
 
       launch_long_task(pool_name)
 
@@ -522,8 +532,12 @@ defmodule PoolexTest do
       assert debug_info.overflow == 0
     end
 
-    test "allows workers_count: 0" do
-      pool_name = start_pool(worker_module: SomeWorker, workers_count: 0, max_overflow: 2)
+    test "allows workers_count: 0", %{pool_options: pool_options} do
+      pool_name =
+        pool_options
+        |> Keyword.merge(workers_count: 0, max_overflow: 2)
+        |> start_pool()
+
       debug_info = Poolex.get_debug_info(pool_name)
 
       assert debug_info.idle_workers_count == 0

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -577,17 +577,13 @@ defmodule PoolexTest do
   end
 
   describe "child_spec" do
-    test "child_spec/1" do
-      assert Poolex.child_spec(pool_id: :test_pool, worker_module: SomeWorker, workers_count: 5) ==
-               %{
-                 id: :test_pool,
-                 start: {Poolex, :start_link, [[pool_id: :test_pool, worker_module: SomeWorker, workers_count: 5]]}
-               }
+    test "child_spec/1", %{pool_options: pool_options} do
+      id = Keyword.fetch!(pool_options, :pool_id)
 
-      assert Poolex.child_spec(pool_id: {:global, :biba}, worker_module: SomeWorker, workers_count: 10) ==
+      assert Poolex.child_spec(pool_options) ==
                %{
-                 id: {:global, :biba},
-                 start: {Poolex, :start_link, [[pool_id: {:global, :biba}, worker_module: SomeWorker, workers_count: 10]]}
+                 id: id,
+                 start: {Poolex, :start_link, [pool_options]}
                }
     end
   end

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -102,8 +102,11 @@ defmodule PoolexTest do
   end
 
   describe "run/2" do
-    test "updates agent's state" do
-      pool_name = start_pool(worker_module: Agent, worker_args: [fn -> 0 end], workers_count: 1)
+    test "updates agent's state", %{pool_options: pool_options} do
+      pool_name =
+        pool_options
+        |> Keyword.merge(worker_module: Agent, worker_args: [fn -> 0 end], workers_count: 1)
+        |> start_pool()
 
       Poolex.run(pool_name, fn pid -> Agent.update(pid, fn _state -> 1 end) end)
 
@@ -112,15 +115,15 @@ defmodule PoolexTest do
       assert 1 == Agent.get(agent_pid, fn state -> state end)
     end
 
-    test "get result from custom worker" do
-      pool_name = start_pool(worker_module: SomeWorker, workers_count: 2)
+    test "get result from custom worker", %{pool_options: pool_options} do
+      pool_name = start_pool(pool_options)
 
       result = Poolex.run(pool_name, fn pid -> GenServer.call(pid, :do_some_work) end)
       assert result == {:ok, :some_result}
     end
 
-    test "test waiting queue" do
-      pool_name = start_pool(worker_module: SomeWorker, workers_count: 5)
+    test "test waiting queue", %{pool_options: pool_options} do
+      pool_name = start_pool(pool_options)
 
       result =
         1..20

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -55,11 +55,10 @@ defmodule PoolexTest do
       assert debug_info.waiting_callers_impl == SomeWaitingCallersImpl
     end
 
-    test "valid after using the worker" do
-      initial_fun = fn -> 0 end
-      pool_name = start_pool(worker_module: Agent, worker_args: [initial_fun], workers_count: 5)
+    test "valid after using the worker", %{pool_options: pool_options} do
+      pool_name = start_pool(pool_options)
 
-      {:ok, 0} = Poolex.run(pool_name, fn pid -> Agent.get(pid, & &1) end)
+      assert {:ok, :some_result} = Poolex.run(pool_name, fn pid -> GenServer.call(pid, :do_some_work) end)
 
       debug_info = Poolex.get_debug_info(pool_name)
 
@@ -68,8 +67,8 @@ defmodule PoolexTest do
       assert Enum.empty?(debug_info.busy_workers_pids)
       assert debug_info.idle_workers_count == 5
       assert Enum.count(debug_info.idle_workers_pids) == 5
-      assert debug_info.worker_module == Agent
-      assert debug_info.worker_args == [initial_fun]
+      assert debug_info.worker_module == SomeWorker
+      assert debug_info.worker_args == []
       assert debug_info.waiting_callers == []
     end
 

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -652,20 +652,16 @@ defmodule PoolexTest do
   end
 
   describe "add_idle_workers!/2" do
-    test "adds idle workers to pool" do
-      initial_fun = fn -> 0 end
-
-      pool_name = start_pool(worker_module: Agent, worker_args: [initial_fun], workers_count: 5)
+    test "adds idle workers to pool", %{pool_options: pool_options} do
+      pool_name = start_pool(pool_options)
 
       assert %DebugInfo{idle_workers_count: 5} = Poolex.get_debug_info(pool_name)
       assert :ok = Poolex.add_idle_workers!(pool_name, 5)
       assert %DebugInfo{idle_workers_count: 10} = Poolex.get_debug_info(pool_name)
     end
 
-    test "raises error on non positive workers_count" do
-      initial_fun = fn -> 0 end
-
-      pool_name = start_pool(worker_module: Agent, worker_args: [initial_fun], workers_count: 5)
+    test "raises error on non positive workers_count", %{pool_options: pool_options} do
+      pool_name = start_pool(pool_options)
 
       assert_raise(ArgumentError, fn ->
         Poolex.add_idle_workers!(pool_name, -1)

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -72,9 +72,8 @@ defmodule PoolexTest do
       assert debug_info.waiting_callers == []
     end
 
-    test "valid after holding some workers" do
-      initial_fun = fn -> 0 end
-      pool_name = start_pool(worker_module: Agent, worker_args: [initial_fun], workers_count: 5)
+    test "valid after holding some workers", %{pool_options: pool_options} do
+      pool_name = start_pool(pool_options)
 
       test_process = self()
 
@@ -96,8 +95,8 @@ defmodule PoolexTest do
       assert Enum.count(debug_info.busy_workers_pids) == 1
       assert debug_info.idle_workers_count == 4
       assert Enum.count(debug_info.idle_workers_pids) == 4
-      assert debug_info.worker_module == Agent
-      assert debug_info.worker_args == [initial_fun]
+      assert debug_info.worker_module == SomeWorker
+      assert debug_info.worker_args == []
       assert debug_info.waiting_callers == []
     end
   end

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -143,10 +143,7 @@ defmodule PoolexTest do
 
   describe "restarting terminated processes" do
     test "works on idle workers", %{pool_options: pool_options} do
-      pool_name =
-        pool_options
-        |> Keyword.put(:workers_count, 1)
-        |> start_pool()
+      pool_name = pool_options |> Keyword.put(:workers_count, 1) |> start_pool()
 
       [some_worker_pid] = Poolex.get_debug_info(pool_name).idle_workers_pids
 
@@ -161,10 +158,7 @@ defmodule PoolexTest do
     end
 
     test "works on busy workers", %{pool_options: pool_options} do
-      pool_name =
-        pool_options
-        |> Keyword.put(:workers_count, 1)
-        |> start_pool()
+      pool_name = pool_options |> Keyword.put(:workers_count, 1) |> start_pool()
 
       test_process = self()
 
@@ -192,10 +186,7 @@ defmodule PoolexTest do
     end
 
     test "restart busy workers when pending callers", %{pool_options: pool_options} do
-      pool_name =
-        pool_options
-        |> Keyword.put(:workers_count, 1)
-        |> start_pool()
+      pool_name = pool_options |> Keyword.put(:workers_count, 1) |> start_pool()
 
       launch_long_tasks(pool_name, 2)
 
@@ -219,10 +210,7 @@ defmodule PoolexTest do
     end
 
     test "works on callers", %{pool_options: pool_options} do
-      pool_name =
-        pool_options
-        |> Keyword.put(:workers_count, 1)
-        |> start_pool()
+      pool_name = pool_options |> Keyword.put(:workers_count, 1) |> start_pool()
 
       Enum.each(1..10, fn _ ->
         spawn(fn ->
@@ -258,10 +246,7 @@ defmodule PoolexTest do
     end
 
     test "release busy worker when caller dies", %{pool_options: pool_options} do
-      pool_name =
-        pool_options
-        |> Keyword.put(:workers_count, 2)
-        |> start_pool()
+      pool_name = pool_options |> Keyword.put(:workers_count, 2) |> start_pool()
 
       caller =
         spawn(fn ->
@@ -288,10 +273,7 @@ defmodule PoolexTest do
     end
 
     test "release busy worker when caller dies (overflow case)", %{pool_options: pool_options} do
-      pool_name =
-        pool_options
-        |> Keyword.merge(workers_count: 0, max_overflow: 2)
-        |> start_pool()
+      pool_name = pool_options |> Keyword.merge(workers_count: 0, max_overflow: 2) |> start_pool()
 
       caller =
         spawn(fn ->
@@ -318,10 +300,7 @@ defmodule PoolexTest do
     end
 
     test "runtime errors", %{pool_options: pool_options} do
-      pool_name =
-        pool_options
-        |> Keyword.put(:workers_count, 1)
-        |> start_pool()
+      pool_name = pool_options |> Keyword.put(:workers_count, 1) |> start_pool()
 
       catch_exit(Poolex.run(pool_name, fn pid -> GenServer.call(pid, :do_raise) end))
 
@@ -337,10 +316,7 @@ defmodule PoolexTest do
 
   describe "timeouts" do
     test "when caller waits too long", %{pool_options: pool_options} do
-      pool_name =
-        pool_options
-        |> Keyword.put(:workers_count, 1)
-        |> start_pool()
+      pool_name = pool_options |> Keyword.put(:workers_count, 1) |> start_pool()
 
       launch_long_task(pool_name)
 
@@ -372,10 +348,7 @@ defmodule PoolexTest do
     end
 
     test "run/3 returns error on checkout timeout", %{pool_options: pool_options} do
-      pool_name =
-        pool_options
-        |> Keyword.put(:workers_count, 1)
-        |> start_pool()
+      pool_name = pool_options |> Keyword.put(:workers_count, 1) |> start_pool()
 
       launch_long_task(pool_name)
 
@@ -397,10 +370,7 @@ defmodule PoolexTest do
     end
 
     test "handle worker's timeout", %{pool_options: pool_options} do
-      pool_name =
-        pool_options
-        |> Keyword.put(:workers_count, 1)
-        |> start_pool()
+      pool_name = pool_options |> Keyword.put(:workers_count, 1) |> start_pool()
 
       delay = 100
 
@@ -420,10 +390,7 @@ defmodule PoolexTest do
     test "worker not hangs in busy status after checkout timeout", %{pool_options: pool_options} do
       test_pid = self()
 
-      pool_name =
-        pool_options
-        |> Keyword.put(:workers_count, 1)
-        |> start_pool()
+      pool_name = pool_options |> Keyword.put(:workers_count, 1) |> start_pool()
 
       delay = 100
 
@@ -475,10 +442,7 @@ defmodule PoolexTest do
 
   describe "overflow" do
     test "create new workers when possible", %{pool_options: pool_options} do
-      pool_name =
-        pool_options
-        |> Keyword.merge(workers_count: 1, max_overflow: 5)
-        |> start_pool()
+      pool_name = pool_options |> Keyword.merge(workers_count: 1, max_overflow: 5) |> start_pool()
 
       launch_long_tasks(pool_name, 5)
 
@@ -489,10 +453,7 @@ defmodule PoolexTest do
     end
 
     test "return error when max count of workers reached", %{pool_options: pool_options} do
-      pool_name =
-        pool_options
-        |> Keyword.put(:workers_count, 1)
-        |> start_pool()
+      pool_name = pool_options |> Keyword.put(:workers_count, 1) |> start_pool()
 
       launch_long_task(pool_name)
 
@@ -513,10 +474,7 @@ defmodule PoolexTest do
     end
 
     test "all workers running over the limit are turned off after use", %{pool_options: pool_options} do
-      pool_name =
-        pool_options
-        |> Keyword.merge(workers_count: 1, max_overflow: 2)
-        |> start_pool()
+      pool_name = pool_options |> Keyword.merge(workers_count: 1, max_overflow: 2) |> start_pool()
 
       launch_long_task(pool_name)
 
@@ -533,10 +491,7 @@ defmodule PoolexTest do
     end
 
     test "allows workers_count: 0", %{pool_options: pool_options} do
-      pool_name =
-        pool_options
-        |> Keyword.merge(workers_count: 0, max_overflow: 2)
-        |> start_pool()
+      pool_name = pool_options |> Keyword.merge(workers_count: 0, max_overflow: 2) |> start_pool()
 
       debug_info = Poolex.get_debug_info(pool_name)
 
@@ -590,10 +545,7 @@ defmodule PoolexTest do
 
   describe "terminate process" do
     test "workers stop before the pool with reason :normal", %{pool_options: pool_options} do
-      pool_name =
-        pool_options
-        |> Keyword.put(:workers_count, 1)
-        |> start_pool()
+      pool_name = pool_options |> Keyword.put(:workers_count, 1) |> start_pool()
 
       pool_pid = GenServer.whereis(pool_name)
 
@@ -616,10 +568,7 @@ defmodule PoolexTest do
     end
 
     test "workers stop before the pool with reason :exit", %{pool_options: pool_options} do
-      pool_name =
-        pool_options
-        |> Keyword.put(:workers_count, 1)
-        |> start_pool()
+      pool_name = pool_options |> Keyword.put(:workers_count, 1) |> start_pool()
 
       pool_pid = GenServer.whereis(pool_name)
 

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -16,7 +16,7 @@ defmodule PoolexTest do
 
   alias Poolex.Private.DebugInfo
 
-  setup do
+  setup_all do
     if Version.match?(System.version(), ">= 1.18.0") do
       []
     else

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -589,9 +589,13 @@ defmodule PoolexTest do
   end
 
   describe "terminate process" do
-    test "workers stop before the pool with reason :normal" do
-      pool_name = start_pool(worker_module: SomeWorker, workers_count: 1)
-      pool_pid = Process.whereis(pool_name)
+    test "workers stop before the pool with reason :normal", %{pool_options: pool_options} do
+      pool_name =
+        pool_options
+        |> Keyword.put(:workers_count, 1)
+        |> start_pool()
+
+      pool_pid = GenServer.whereis(pool_name)
 
       state = :sys.get_state(pool_name)
 
@@ -611,9 +615,13 @@ defmodule PoolexTest do
       assert message_3 == {:DOWN, pool_monitor_ref, :process, pool_pid, :normal}
     end
 
-    test "workers stop before the pool with reason :exit" do
-      pool_name = start_pool(worker_module: SomeWorker, workers_count: 1)
-      pool_pid = Process.whereis(pool_name)
+    test "workers stop before the pool with reason :exit", %{pool_options: pool_options} do
+      pool_name =
+        pool_options
+        |> Keyword.put(:workers_count, 1)
+        |> start_pool()
+
+      pool_pid = GenServer.whereis(pool_name)
 
       state = :sys.get_state(pool_name)
 

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -38,15 +38,15 @@ defmodule PoolexTest do
       assert debug_info.waiting_callers_impl == Poolex.Callers.Impl.ErlangQueue
     end
 
-    test "valid configured implementations" do
+    test "valid configured implementations", %{pool_options: pool_options} do
       pool_name =
-        start_pool(
-          worker_module: SomeWorker,
-          workers_count: 10,
+        pool_options
+        |> Keyword.merge(
           busy_workers_impl: SomeBusyWorkersImpl,
           idle_workers_impl: SomeIdleWorkersImpl,
           waiting_callers_impl: SomeWaitingCallersImpl
         )
+        |> start_pool()
 
       debug_info = Poolex.get_debug_info(pool_name)
 

--- a/test/support/pool_helpers.ex
+++ b/test/support/pool_helpers.ex
@@ -5,19 +5,9 @@ defmodule PoolHelpers do
 
   @spec start_pool(list(Poolex.poolex_option())) :: Poolex.pool_id()
   def start_pool(options) do
-    pool_name = Keyword.get(options, :pool_id, generate_pool_name())
-
-    options = Keyword.put(options, :pool_id, pool_name)
     {:ok, _pid} = ExUnit.Callbacks.start_supervised({Poolex, options})
 
-    pool_name
-  end
-
-  defp generate_pool_name do
-    1..10
-    |> Enum.map(fn _ -> Enum.random(?a..?z) end)
-    |> to_string()
-    |> String.to_atom()
+    Keyword.fetch!(options, :pool_id)
   end
 
   @spec launch_long_task(Poolex.pool_id(), timeout()) :: :ok

--- a/test/support/pool_helpers.ex
+++ b/test/support/pool_helpers.ex
@@ -5,16 +5,20 @@ defmodule PoolHelpers do
 
   @spec start_pool(list(Poolex.poolex_option())) :: Poolex.pool_id()
   def start_pool(options) do
-    pool_name =
-      1..10
-      |> Enum.map(fn _ -> Enum.random(?a..?z) end)
-      |> to_string()
-      |> String.to_atom()
+    {pool_name, options} = Keyword.pop(options, :pool_id)
+    pool_name = pool_name || generate_pool_name()
 
     options = Keyword.put(options, :pool_id, pool_name)
     {:ok, _pid} = ExUnit.Callbacks.start_supervised({Poolex, options})
 
     pool_name
+  end
+
+  defp generate_pool_name do
+    1..10
+    |> Enum.map(fn _ -> Enum.random(?a..?z) end)
+    |> to_string()
+    |> String.to_atom()
   end
 
   @spec launch_long_task(Poolex.pool_id(), timeout()) :: :ok

--- a/test/support/pool_helpers.ex
+++ b/test/support/pool_helpers.ex
@@ -5,8 +5,7 @@ defmodule PoolHelpers do
 
   @spec start_pool(list(Poolex.poolex_option())) :: Poolex.pool_id()
   def start_pool(options) do
-    {pool_name, options} = Keyword.pop(options, :pool_id)
-    pool_name = pool_name || generate_pool_name()
+    pool_name = Keyword.get(options, :pool_id, generate_pool_name())
 
     options = Keyword.put(options, :pool_id, pool_name)
     {:ok, _pid} = ExUnit.Callbacks.start_supervised({Poolex, options})

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,3 @@
 ExUnit.start()
+
+Registry.start_link(keys: :unique, name: PoolexTestRegistry)


### PR DESCRIPTION
### Changed

- Refactored tests with new [ExUnit parameterize feature](https://hexdocs.pm/ex_unit/1.18.0/ExUnit.Case.html#module-parameterized-tests).

### Fixed

- The functions `Poolex.add_idle_workers!/2` and `Poolex.remove_idle_workers!/2` now accept any value of type `GenServer.name()` as their first argument, instead of only `atom()`.