### PR TITLE
New workers providing to waiting callers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Now the `busy_worker` will be restarted after the `caller's` death. Read more in [issue](https://github.com/general-CbIC/poolex/issues/114).
+- The function `add_idle_workers!/2` now provides new workers to waiting callers if they exist. Read more in [issue](https://github.com/general-CbIC/poolex/issues/122).
 
 ## [1.2.0] - 2025-01-07
 

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -648,6 +648,7 @@ defmodule PoolexTest do
         Process.send(test_process, nil, [])
 
         Poolex.run(pool_name, fn _pid ->
+          Process.send(test_process, :started_work, [])
           :timer.sleep(:timer.seconds(5))
         end)
       end)
@@ -660,6 +661,7 @@ defmodule PoolexTest do
       assert debug_info.busy_workers_count == 0
       assert debug_info.idle_workers_count == 0
       assert Enum.count(debug_info.waiting_callers) == 1
+      refute_received :started_work
 
       assert :ok = Poolex.add_idle_workers!(pool_name, 1)
 
@@ -667,6 +669,7 @@ defmodule PoolexTest do
       assert debug_info.busy_workers_count == 1
       assert debug_info.idle_workers_count == 0
       assert Enum.empty?(debug_info.waiting_callers)
+      assert_receive :started_work, 1000
     end
 
     test "raises error on non positive workers_count", %{pool_options: pool_options} do


### PR DESCRIPTION
The function `add_idle_workers!/2` now provides new workers to waiting_callers if they exist.

Closes #122 