### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -16,14 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - elixir: '1.7'
-            otp: '22'
-          - elixir: '1.8'
-            otp: '22'
-          - elixir: '1.9'
-            otp: '22'
-          - elixir: '1.10'
-            otp: '23'
           - elixir: '1.11'
             otp: '24'
           - elixir: '1.12'
@@ -72,6 +64,6 @@ jobs:
         uses: erlef/setup-beam@v1
         with:
           otp-version: '27'
-          elixir-version: '1.17'
+          elixir-version: '1.18'
       - run: mix do deps.get, compile
       - run: mix check

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -51,12 +51,13 @@ jobs:
         run: |
           mix_hash="${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}"
           echo "mix_hash=$mix_hash" >> $GITHUB_ENV
-      - name: Cache PLT files
+      - name: Cache PLT files and deps
         uses: actions/cache@v4
         with:
           path: |
             _build/dev/*.plt
             _build/dev/*.plt.hash
+            deps/
           key: plt-cache-${{ env.mix_hash }}
           restore-keys: |
             plt-cache-

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
     strategy:
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Due to the deprecation of support ubuntu 20.04 on GitHub Actions (read more [here](https://github.com/actions/runner-images/issues/11101)), bumped minimum required versions of Elixir to `~> 1.11` and Erlang/OTP to `~> 24`.
+
 ## [1.2.1] - 2025-04-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added caching of the dependencies on CI (compilation speed up).
+
 ### Changed
 
 - Due to the deprecation of support ubuntu 20.04 on GitHub Actions (read more [here](https://github.com/actions/runner-images/issues/11101)), bumped minimum required versions of Elixir to `~> 1.11` and Erlang/OTP to `~> 24`.

--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ With `poolex` you can:
 **Why `poolex` instead of `poolboy`?**
   
 - `poolex` is written in Elixir. This library is much more convenient to use in Elixir projects.
-- `poolboy` is a great library, but not actively maintained :crying_cat_face:![Last poolboy commit](https://img.shields.io/github/last-commit/devinus/poolboy?style=flat)
+- `poolboy` is a great library, but not actively maintained :crying_cat_face: ![Last poolboy commit](https://img.shields.io/github/last-commit/devinus/poolboy?style=flat)
 
 ## Requirements
 
-| Requirement | Version |
-|-------------|---------|
-| Erlang/OTP  | >= 22   |
-| Elixir      | >= 1.7  |
+| Library | Elixir  | Erlang/OTP |
+|---------|---------|------------|
+| < 1.3   | >= 1.7  | >= 22      |
+| >= 1.3  | >= 1.11 | >= 24      |
 
 ## Installation
 

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Poolex.MixProject do
       deps: deps(),
       description: "The library for managing pools of workers.",
       docs: docs(),
-      elixir: "~> 1.7",
+      elixir: "~> 1.11",
       elixirc_options: [
         warnings_as_errors: true
       ],


### PR DESCRIPTION
- Added caching of the dependencies (compilation speed up)
- Elixir version on the main "linter and tests" task update to 1.18
- Updated ubuntu version from 20 to 22 because of the deprecation (read more about it [here](https://github.com/actions/runner-images/issues/11101))