### PR TITLE
Fix worker leak on checkout timeout racing with worker hand-off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a worker leak: when a worker hand-off raced with the caller's checkout timeout (or the caller's death), the lost reply left the worker permanently stuck among busy workers. The pool now tracks unconfirmed hand-offs and reclaims such workers.
+
+### Changed
+
+- `cancel_waiting` is no longer sent to the pool on every successful checkout, only when the checkout times out.
+
 ## [1.6.3] - 2026-05-10
 
 ### Changed

--- a/TODO.md
+++ b/TODO.md
@@ -54,46 +54,6 @@ end
 
 Pass `caller_pid` alongside `worker_pid` when sending `{:stop_worker}` from the monitor process.
 
-### Fix worker leak on simultaneous timeout and release
-
-**Current problem (`lib/poolex.ex:297`):**
-
-A worker can get permanently stuck in `BusyWorkers` if a caller's checkout timeout races with a worker becoming available:
-
-1. No idle workers — caller is added to `waiting_callers`
-2. Caller times out → `GenServer.call` returns `{:error, :checkout_timeout}`
-3. Simultaneously, a worker is released → pool calls `provide_worker_to_waiting_caller` (`lib/poolex.ex:739`) → `GenServer.reply(caller.from, {:ok, worker})`
-4. The reply is lost (caller already returned from its timed-out `call`)
-5. Pool then processes `{:cancel_waiting, ref}` — but the caller was already popped from the queue
-6. Worker is now stuck in `BusyWorkers` indefinitely (until it crashes)
-
-**Proposed fix:**
-In `provide_worker_to_waiting_caller`, check that the caller process is still alive before replying:
-
-```elixir
-defp provide_worker_to_waiting_caller(%State{} = state, worker) do
-  {caller, state} = WaitingCallers.pop(state)
-  {from_pid, _tag} = caller.from
-
-  if Process.alive?(from_pid) do
-    GenServer.reply(caller.from, {:ok, worker})
-    state
-  else
-    # Dead caller — try the next one, or return the worker to the pool
-    if WaitingCallers.empty?(state) do
-      release_busy_worker(state, worker)
-    else
-      provide_worker_to_waiting_caller(state, worker)
-    end
-  end
-end
-```
-
-**Notes:**
-
-- `Process.alive?/1` is not perfectly atomic but eliminates the common case. A fully correct solution would require a two-phase acknowledgement protocol.
-- `Process.alive?/1` raises for remote pids — guard with `node(from_pid) == node()` if cross-node calls should be supported.
-
 ### Fix dangling caller monitors (both timeout and success paths)
 
 **Current problem:**
@@ -111,6 +71,8 @@ The pool monitors every caller placed into the waiting queue (`Monitoring.add(fr
 **Proposed fix:**
 Demonitor when the caller leaves the queue (both paths). Easiest path: store `monitor_ref` inside `Poolex.Caller` so it is available on pop/remove. Cleaner path: after the `Process.link` refactor below, this bookkeeping goes away.
 
+**Caveat:** `handle_down_waiting_caller/2` now also reclaims unconfirmed checkouts (see `reclaim_unconfirmed_checkouts_of_caller/2`) and relies on the caller staying monitored after the hand-off. When adding demonitor-on-hand-off, keep the caller monitored until the checkout is confirmed via `register_manual_acquisition`, or reclaim unconfirmed workers some other way.
+
 ### Make `acquire/2` atomic (race between `get_idle_worker` and `register_manual_acquisition`)
 
 **Current problem (`lib/poolex.ex:249-260`):**
@@ -120,10 +82,12 @@ Demonitor when the caller leaves the queue (both paths). Easiest path: store `mo
 1. `{:get_idle_worker, ref}` — worker is moved to `BusyWorkers`
 2. `{:register_manual_acquisition, self(), worker_pid}` — monitor is set up
 
-If the caller process dies **between** these two calls, the worker is stuck in `BusyWorkers` with no monitor and no entry in `manual_monitors` — pool has no way to reclaim it until the worker itself crashes.
+If the caller process dies **between** these two calls, the worker is stuck in `BusyWorkers` with no monitor and no entry in `manual_monitors`.
+
+Since the unconfirmed-checkouts tracking was added, callers that went through the waiting queue are covered: they are monitored, and their DOWN message reclaims the unconfirmed worker. The gap remains for **direct** checkouts (worker was available immediately): the caller is not monitored at that point, so the worker and its `unconfirmed_checkouts` entry are stuck until the worker itself crashes.
 
 **Proposed fix:**
-Collapse into a single atomic call that takes the worker and registers the monitor in one `handle_call`. The caller pid is trivially available via `GenServer.call`'s `from` argument, so no extra data needs to be passed.
+Collapse into a single atomic call that takes the worker and registers the monitor in one `handle_call`. The caller pid is trivially available via `GenServer.call`'s `from` argument, so no extra data needs to be passed. This also makes the unconfirmed-checkouts bookkeeping simpler: hand-off and confirmation become one step.
 
 ## Architecture Improvements
 
@@ -199,15 +163,6 @@ monitors: %{reference() => :worker | :waiting_caller}
 - Drop `start_manual_monitor/3`, `:cleanup_manual_monitor`, `:stop_worker` casts entirely.
 
 Eliminates the race condition, removes a whole layer of processes, reduces mailbox churn.
-
-### Skip `cancel_waiting` cast on successful checkout
-
-**Current problem (`lib/poolex.ex:306`):**
-
-The `after` block in `get_idle_worker/2` casts `{:cancel_waiting, ref}` on **every** call, including successful checkouts. On success the caller is guaranteed not to be in the waiting queue (it was either replied to directly or popped before the reply), so the pool does a useless O(n) `:queue.filter` pass per checkout.
-
-**Proposed fix:**
-Move the cast from the `after` block into the timeout `catch` branch. Non-timeout exits mean the pool itself is down, so no cleanup is needed there either.
 
 ### Stop always-on retry ticker
 

--- a/lib/poolex.ex
+++ b/lib/poolex.ex
@@ -301,9 +301,13 @@ defmodule Poolex do
       GenServer.call(pool_id, {:get_idle_worker, caller_reference}, checkout_timeout)
     catch
       :exit, {:timeout, {GenServer, :call, [_pool_id, {:get_idle_worker, ^caller_reference}, _timeout]}} ->
+        # The pool may have provided a worker right as the call timed out — then the reply is
+        # lost. `cancel_waiting` either removes the caller from the waiting queue or reclaims
+        # the worker from the unconfirmed checkout. It must not be sent on the success path:
+        # there it would reclaim a worker the caller legitimately holds.
+        GenServer.cast(pool_id, {:cancel_waiting, caller_reference})
+
         {:error, :checkout_timeout}
-    after
-      GenServer.cast(pool_id, {:cancel_waiting, caller_reference})
     end
   end
 
@@ -467,14 +471,22 @@ defmodule Poolex do
       not IdleOverflowedWorkers.empty?(state) ->
         # If there are overflowed idle workers, we can immediately provide one to the caller
         {overflowed_worker_pid, state} = IdleOverflowedWorkers.pop(state)
-        state = BusyWorkers.add(state, overflowed_worker_pid)
+
+        state =
+          state
+          |> BusyWorkers.add(overflowed_worker_pid)
+          |> record_unconfirmed_checkout(overflowed_worker_pid, from_pid, caller_reference)
 
         {:reply, {:ok, overflowed_worker_pid}, state}
 
       not IdleWorkers.empty?(state) ->
         # If there are idle workers, we can immediately provide one to the caller
         {idle_worker_pid, state} = IdleWorkers.pop(state)
-        state = BusyWorkers.add(state, idle_worker_pid)
+
+        state =
+          state
+          |> BusyWorkers.add(idle_worker_pid)
+          |> record_unconfirmed_checkout(idle_worker_pid, from_pid, caller_reference)
 
         {:reply, {:ok, idle_worker_pid}, state}
 
@@ -483,7 +495,10 @@ defmodule Poolex do
         case start_worker(state) do
           {:ok, new_worker, state} ->
             # When worker created successfully
-            state = BusyWorkers.add(state, new_worker)
+            state =
+              state
+              |> BusyWorkers.add(new_worker)
+              |> record_unconfirmed_checkout(new_worker, from_pid, caller_reference)
 
             {:reply, {:ok, new_worker}, %{state | overflow: state.overflow + 1}}
 
@@ -510,6 +525,10 @@ defmodule Poolex do
 
   def handle_call({:register_manual_acquisition, caller_pid, worker_pid}, _from, %State{} = state) do
     monitor_pid = start_manual_monitor(state.pool_id, caller_pid, worker_pid)
+
+    # The caller has confirmed that it received the worker, no need to track the hand-off anymore
+    state = remove_unconfirmed_checkout(state, worker_pid)
+
     new_state = put_in(state.manual_monitors[worker_pid], {caller_pid, monitor_pid})
     {:reply, :ok, new_state}
   end
@@ -592,13 +611,7 @@ defmodule Poolex do
 
   @impl GenServer
   def handle_cast({:release_busy_worker, worker}, %State{} = state) do
-    if WaitingCallers.empty?(state) do
-      new_state = release_busy_worker(state, worker)
-      {:noreply, new_state}
-    else
-      new_state = provide_worker_to_waiting_caller(state, worker)
-      {:noreply, new_state}
-    end
+    {:noreply, return_worker_to_pool(state, worker)}
   end
 
   @impl GenServer
@@ -624,11 +637,7 @@ defmodule Poolex do
     # Only release worker if caller was the owner
     new_state =
       if caller_is_owner do
-        if WaitingCallers.empty?(state) do
-          release_busy_worker(state, worker_pid)
-        else
-          provide_worker_to_waiting_caller(state, worker_pid)
-        end
+        return_worker_to_pool(state, worker_pid)
       else
         state
       end
@@ -660,7 +669,12 @@ defmodule Poolex do
 
   @impl GenServer
   def handle_cast({:cancel_waiting, caller_reference}, %State{} = state) do
-    {:noreply, WaitingCallers.remove_by_reference(state, caller_reference)}
+    state =
+      state
+      |> WaitingCallers.remove_by_reference(caller_reference)
+      |> reclaim_unconfirmed_checkout(caller_reference)
+
+    {:noreply, state}
   end
 
   @impl GenServer
@@ -735,13 +749,81 @@ defmodule Poolex do
     end
   end
 
+  # Returns a busy worker back to the pool: gives it to a waiting caller if there is one,
+  # otherwise makes it idle (or shuts it down if it is an overflow worker).
+  @spec return_worker_to_pool(State.t(), worker()) :: State.t()
+  defp return_worker_to_pool(%State{} = state, worker) do
+    if WaitingCallers.empty?(state) do
+      release_busy_worker(state, worker)
+    else
+      provide_worker_to_waiting_caller(state, worker)
+    end
+  end
+
   @spec provide_worker_to_waiting_caller(State.t(), worker()) :: State.t()
   defp provide_worker_to_waiting_caller(%State{} = state, worker) do
-    {caller, state} = WaitingCallers.pop(state)
+    {%Poolex.Caller{reference: caller_reference, from: {caller_pid, _tag} = from}, state} = WaitingCallers.pop(state)
 
-    GenServer.reply(caller.from, {:ok, worker})
+    if caller_alive?(caller_pid) do
+      GenServer.reply(from, {:ok, worker})
 
-    state
+      record_unconfirmed_checkout(state, worker, caller_pid, caller_reference)
+    else
+      # The caller died while waiting, but its DOWN message has not been processed yet.
+      # Give the worker to the next waiting caller or return it to the pool.
+      return_worker_to_pool(state, worker)
+    end
+  end
+
+  # Pids from remote nodes cannot be checked with `Process.alive?/1`, assume they are alive:
+  # lost hand-offs to them are still reclaimed via `cancel_waiting` or their DOWN message.
+  @spec caller_alive?(pid()) :: boolean()
+  defp caller_alive?(caller_pid) do
+    node(caller_pid) != node() or Process.alive?(caller_pid)
+  end
+
+  # A reply with a worker can be lost: the caller's `GenServer.call` may time out at the same
+  # moment the pool replies, or the caller may die before receiving the reply. Until the caller
+  # confirms the receipt with `register_manual_acquisition`, the hand-off is tracked in
+  # `unconfirmed_checkouts` so the worker can be reclaimed instead of leaking in busy workers.
+  @spec record_unconfirmed_checkout(State.t(), worker(), pid(), reference()) :: State.t()
+  defp record_unconfirmed_checkout(%State{} = state, worker, caller_pid, caller_reference) do
+    %{state | unconfirmed_checkouts: Map.put(state.unconfirmed_checkouts, worker, {caller_pid, caller_reference})}
+  end
+
+  @spec remove_unconfirmed_checkout(State.t(), worker()) :: State.t()
+  defp remove_unconfirmed_checkout(%State{} = state, worker) do
+    %{state | unconfirmed_checkouts: Map.delete(state.unconfirmed_checkouts, worker)}
+  end
+
+  # Called when a caller reports with `cancel_waiting` that it has given up (checkout timeout).
+  # If a worker was already handed to that caller, the reply was lost — reclaim the worker.
+  @spec reclaim_unconfirmed_checkout(State.t(), reference()) :: State.t()
+  defp reclaim_unconfirmed_checkout(%State{} = state, caller_reference) do
+    case Enum.find(state.unconfirmed_checkouts, fn {_worker, {_caller_pid, reference}} ->
+           reference == caller_reference
+         end) do
+      nil ->
+        state
+
+      {worker, _} ->
+        state
+        |> remove_unconfirmed_checkout(worker)
+        |> return_worker_to_pool(worker)
+    end
+  end
+
+  # Called when a monitored caller dies: reclaim workers that were handed to it
+  # but whose receipt was never confirmed.
+  @spec reclaim_unconfirmed_checkouts_of_caller(State.t(), pid()) :: State.t()
+  defp reclaim_unconfirmed_checkouts_of_caller(%State{} = state, caller_pid) do
+    state.unconfirmed_checkouts
+    |> Enum.filter(fn {_worker, {pid, _reference}} -> pid == caller_pid end)
+    |> Enum.reduce(state, fn {worker, _}, acc_state ->
+      acc_state
+      |> remove_unconfirmed_checkout(worker)
+      |> return_worker_to_pool(worker)
+    end)
   end
 
   @spec handle_down_worker(State.t(), pid()) :: State.t()
@@ -751,6 +833,7 @@ defmodule Poolex do
       |> IdleWorkers.remove(dead_process_pid)
       |> BusyWorkers.remove(dead_process_pid)
       |> IdleOverflowedWorkers.remove(dead_process_pid)
+      |> remove_unconfirmed_checkout(dead_process_pid)
 
     cond do
       not WaitingCallers.empty?(state) ->
@@ -785,7 +868,9 @@ defmodule Poolex do
 
   @spec handle_down_waiting_caller(State.t(), pid()) :: State.t()
   defp handle_down_waiting_caller(%State{} = state, dead_process_pid) do
-    WaitingCallers.remove_by_pid(state, dead_process_pid)
+    state
+    |> WaitingCallers.remove_by_pid(dead_process_pid)
+    |> reclaim_unconfirmed_checkouts_of_caller(dead_process_pid)
   end
 
   @impl GenServer

--- a/lib/poolex/private/state.ex
+++ b/lib/poolex/private/state.ex
@@ -39,6 +39,7 @@ defmodule Poolex.Private.State do
                 manual_monitors: %{},
                 monitors: %{},
                 overflow: 0,
+                unconfirmed_checkouts: %{},
                 waiting_callers_impl: nil,
                 waiting_callers_state: nil
               ]
@@ -61,6 +62,7 @@ defmodule Poolex.Private.State do
           overflow: non_neg_integer(),
           pool_id: Poolex.pool_id(),
           supervisor: pid(),
+          unconfirmed_checkouts: %{(worker_pid :: pid()) => {caller_pid :: pid(), caller_reference :: reference()}},
           waiting_callers_impl: module(),
           waiting_callers_state: nil | Poolex.Callers.Behaviour.state(),
           worker_args: list(any()),

--- a/test/poolex_test.exs
+++ b/test/poolex_test.exs
@@ -498,6 +498,131 @@ defmodule PoolexTest do
       send(process_2, :finish)
       assert_receive {:DOWN, ^reference_2, :process, ^process_2, _}
     end
+
+    test "worker provided to a caller that already timed out is reclaimed", %{pool_options: pool_options} do
+      pool_name = pool_options |> Keyword.put(:workers_count, 1) |> start_pool()
+
+      {:ok, worker} = Poolex.acquire(pool_name)
+
+      test_pid = self()
+
+      waiting_caller =
+        spawn(fn ->
+          result = Poolex.run(pool_name, fn _pid -> :ok end, checkout_timeout: 100)
+          send(test_pid, {:checkout_result, result})
+
+          receive do
+            :finish -> :ok
+          end
+        end)
+
+      :timer.sleep(10)
+
+      debug_info = DebugInfo.get_debug_info(pool_name)
+      assert length(debug_info.waiting_callers) == 1
+
+      # Suspend the pool so that the released worker and the caller's timeout "cross paths":
+      # the pool hands the worker to the caller only after the caller has given up waiting,
+      # so the reply is lost.
+      :sys.suspend(pool_name)
+      Poolex.release(pool_name, worker)
+      assert_receive {:checkout_result, {:error, :checkout_timeout}}, 1000
+      :sys.resume(pool_name)
+
+      debug_info = DebugInfo.get_debug_info(pool_name)
+      assert debug_info.busy_workers_count == 0
+      assert debug_info.idle_workers_pids == [worker]
+      assert Enum.empty?(debug_info.waiting_callers)
+
+      send(waiting_caller, :finish)
+    end
+
+    test "worker released to a dead waiting caller is returned to the pool", %{pool_options: pool_options} do
+      pool_name = pool_options |> Keyword.put(:workers_count, 1) |> start_pool()
+
+      {:ok, worker} = Poolex.acquire(pool_name)
+
+      waiting_caller =
+        spawn(fn ->
+          Poolex.run(pool_name, fn _pid -> :ok end, checkout_timeout: :infinity)
+        end)
+
+      :timer.sleep(10)
+
+      debug_info = DebugInfo.get_debug_info(pool_name)
+      assert length(debug_info.waiting_callers) == 1
+
+      # The pool processes the release only after the waiting caller has died,
+      # but before the caller's DOWN message.
+      :sys.suspend(pool_name)
+      Poolex.release(pool_name, worker)
+
+      reference = Process.monitor(waiting_caller)
+      Process.exit(waiting_caller, :kill)
+      assert_receive {:DOWN, ^reference, :process, ^waiting_caller, :killed}, 1000
+
+      :sys.resume(pool_name)
+
+      debug_info = DebugInfo.get_debug_info(pool_name)
+      assert debug_info.busy_workers_count == 0
+      assert debug_info.idle_workers_pids == [worker]
+    end
+
+    test "worker handed to a waiting caller that dies before confirming is reclaimed", %{
+      pool_options: pool_options
+    } do
+      pool_name = pool_options |> Keyword.put(:workers_count, 1) |> start_pool()
+
+      {:ok, worker} = Poolex.acquire(pool_name)
+
+      test_pid = self()
+
+      # Bypasses acquire/2 to simulate the caller dying between receiving the worker
+      # and confirming the acquisition
+      waiting_caller =
+        spawn(fn ->
+          {:ok, worker_pid} = GenServer.call(pool_name, {:get_idle_worker, make_ref()}, :infinity)
+          send(test_pid, {:got_worker, worker_pid})
+          Process.sleep(:infinity)
+        end)
+
+      :timer.sleep(10)
+
+      debug_info = DebugInfo.get_debug_info(pool_name)
+      assert length(debug_info.waiting_callers) == 1
+
+      Poolex.release(pool_name, worker)
+      assert_receive {:got_worker, ^worker}, 1000
+
+      reference = Process.monitor(waiting_caller)
+      Process.exit(waiting_caller, :kill)
+      assert_receive {:DOWN, ^reference, :process, ^waiting_caller, :killed}, 1000
+
+      :timer.sleep(10)
+
+      debug_info = DebugInfo.get_debug_info(pool_name)
+      assert debug_info.busy_workers_count == 0
+      assert debug_info.idle_workers_pids == [worker]
+    end
+
+    test "cancel_waiting after a lost checkout reply reclaims the worker", %{pool_options: pool_options} do
+      pool_name = pool_options |> Keyword.put(:workers_count, 1) |> start_pool()
+
+      caller_reference = make_ref()
+
+      # Simulate a caller whose `call` timed out right when the pool replied:
+      # the worker is checked out, but the caller never received it and cancels.
+      assert {:ok, worker} = GenServer.call(pool_name, {:get_idle_worker, caller_reference})
+
+      debug_info = DebugInfo.get_debug_info(pool_name)
+      assert debug_info.busy_workers_count == 1
+
+      GenServer.cast(pool_name, {:cancel_waiting, caller_reference})
+
+      debug_info = DebugInfo.get_debug_info(pool_name)
+      assert debug_info.busy_workers_count == 0
+      assert debug_info.idle_workers_pids == [worker]
+    end
   end
 
   describe "overflow" do


### PR DESCRIPTION
A worker could get permanently stuck among busy workers when the pool handed it to a caller whose `GenServer.call` had just timed out (the reply was silently lost), or to a caller that had died while waiting.

The pool now tracks every hand-off as an unconfirmed checkout (worker -> {caller, reference}) until the caller confirms the receipt with register_manual_acquisition. Lost hand-offs are reclaimed:

- on `{:cancel_waiting, ref}` (sent by the caller on checkout timeout),
- on the caller's DOWN message,
- and dead waiting callers are skipped at hand-off time entirely.

The cancel_waiting cast is now sent only on timeout instead of after every checkout: on the success path it would wrongly reclaim a worker the caller legitimately holds, and it was a useless queue pass anyway.